### PR TITLE
Add wheel builds to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
         - CIBW_SKIP="cp27-* cp34-*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
-        - CIBW_TEST_COMMAND="python -m unittest {project}/tests"
+        - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       script:
         - sudo pip2 install cibuildwheel==0.10.2
         - cibuildwheel --output-dir wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
 #      if: tag IS present
       script:
-        - sudo pip install cibuildwheel==0.10.2
+        - sudo pip install cibuildwheel==0.10.2 twine
         - cibuildwheel --output-dir wheelhouse
 #        - twine upload wheelhouse/*
     - os: osx
@@ -57,7 +57,7 @@ jobs:
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       script:
-        - sudo pip2 install cibuildwheel==0.10.2
+        - sudo pip2 install cibuildwheel==0.10.2 twine
         - cibuildwheel --output-dir wheelhouse
 #        - twine upload wheelhouse/*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
       env:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && tools/install_rust.sh"
         - CIBW_SKIP="cp27-* cp34-*"
-        - CIBW_ENVIRONMENT="PATH=$PATH:$HOME/.cargo/bin"
+        - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
 #      if: tag IS present
@@ -53,7 +53,7 @@ jobs:
       env:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && tools/install_rust.sh"
         - CIBW_SKIP="cp27-* cp34-*"
-        - CIBW_ENVIRONMENT="PATH=$PATH:$HOME/.cargo/bin"
+        - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest {project}/tests"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ jobs:
     - sudo: required
       services:
         - docker
+      before_install:
+          - echo ""
+      install:
+          - echo ""
       env:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && tools/install_rust.sh"
         - CIBW_SKIP="cp27-* cp34-*"
@@ -41,6 +45,10 @@ jobs:
     - os: osx
       language: generic
 #      if: tag IS present
+      before_install:
+          - echo ""
+      install:
+          - echo ""
       env:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && tools/install_rust.sh"
         - CIBW_SKIP="cp27-* cp34-*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,14 @@ jobs:
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-#      if: tag IS present
+      if: tag IS present
       script:
         - sudo pip install cibuildwheel==0.10.2 twine
         - cibuildwheel --output-dir wheelhouse
-#        - twine upload wheelhouse/*
+        - twine upload wheelhouse/*
     - os: osx
       language: generic
-#      if: tag IS present
+      if: tag IS present
       before_install:
           - echo ""
       install:
@@ -59,6 +59,6 @@ jobs:
       script:
         - sudo pip2 install cibuildwheel==0.10.2 twine
         - cibuildwheel --output-dir wheelhouse
-#        - twine upload wheelhouse/*
+        - twine upload wheelhouse/*
 
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ jobs:
       env:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && tools/install_rust.sh"
         - CIBW_SKIP="cp27-* cp34-*"
+        - CIBW_ENVIRONMENT="PATH=$PATH:$HOME/.cargo/bin"
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
 #      if: tag IS present
@@ -52,6 +53,7 @@ jobs:
       env:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && tools/install_rust.sh"
         - CIBW_SKIP="cp27-* cp34-*"
+        - CIBW_ENVIRONMENT="PATH=$PATH:$HOME/.cargo/bin"
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest {project}/tests"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,30 @@ jobs:
       dist: xenial
       python: 3.7
       sudo: true
+    - sudo: required
+      services:
+        - docker
+      env:
+        - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && tools/install_rust.sh"
+        - CIBW_SKIP="cp27-* cp34-*"
+        - TWINE_USERNAME=retworkx-ci
+        - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
+#      if: tag IS present
+      script:
+        - sudo pip install cibuildwheel==0.10.2
+        - cibuildwheel --output-dir wheelhouse
+#        - twine upload wheelhouse/*
+    - os: osx
+      language: generic
+#      if: tag IS present
+      env:
+        - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && tools/install_rust.sh"
+        - CIBW_SKIP="cp27-* cp34-*"
+        - TWINE_USERNAME=retworkx-ci
+        - CIBW_TEST_COMMAND="python -m unittest {project}/tests"
+      script:
+        - sudo pip2 install cibuildwheel==0.10.2
+        - cibuildwheel --output-dir wheelhouse
+#        - twine upload wheelhouse/*
+
 language: python


### PR DESCRIPTION
This commit adds wheel building to the travis builds. It will only run
on tag pushes so the wheel uploads are done on when we push a release.