### PR TITLE
Add CI jobs for osx to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,35 @@ notifications:
 
 cache: pip
 
+stage_osx: &stage_osx
+  os: osx
+  language: generic
+  cache:
+    pip: true
+    directories:
+      - ~/python-interpreters/
+  before_install:
+    # Travis does not provide support for Python 3 under osx - it needs to be
+    # installed manually.
+    - |
+      if [[ ! -d ~/python-interpreters/$PYTHON_VERSION ]]; then
+        git clone git://github.com/pyenv/pyenv.git
+        cd pyenv/plugins/python-build
+        ./install.sh
+        cd ../../..
+        python-build $PYTHON_VERSION ~/python-interpreters/$PYTHON_VERSION
+      fi
+      sudo pip2 install -U virtualenv pip setuptools
+      virtualenv --python ~/python-interpreters/$PYTHON_VERSION/bin/python venv
+      source venv/bin/activate
+    - which python
+    - sh tools/install_rust.sh
+    - export PATH=~/.cargo/bin:$PATH
+  install:
+    - pip install -U .
+  script:
+    - cd tests && python -m unittest discover .
+
 before_install:
     - which python
     - sh tools/install_rust.sh
@@ -28,6 +57,24 @@ jobs:
     - name: Python 3.8 Tests Linux
       python: 3.8
       dist: bionic
+
+    - name: Python 3.5 Tests OSX
+      <<: *stage_osx
+      env:
+        - PYTHON_VERSION=3.5.8
+    - name: Python 3.6 Tests OSX
+      <<: *stage_osx
+      env:
+        - PYTHON_VERSION=3.6.9
+    - name: Python 3.7 Tests OSX
+      <<: *stage_osx
+      env:
+        - PYTHON_VERSION=3.7.5
+    - name: Python 3.8 Tests OSX
+      <<: *stage_osx
+      env:
+        - PYTHON_VERSION=3.8.0
+
     - services:
         - docker
       before_install:


### PR DESCRIPTION
This commit adds CI configuration to run tests on osx too. retworkx
supports running on osx, linux, and windows yet it was only testing
linux and windows in ci which left osx potentially open to breaking
inadvertently. This should prevent that moving forward by verifying
that new changes run on osx too.