### PR TITLE
Remove daggy dependency and use StableGraph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,8 @@ name = "retworkx"
 crate-type = ["cdylib"]
 
 [dependencies]
-petgraph = "0.4"
-daggy = "0.6"
+petgraph = "0.5"
 
 [dependencies.pyo3]
-version = "0.8.3"
+version = "0.8.5"
 features = ["extension-module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 petgraph = "0.5"
+fixedbitset = "0.2.0"
 
 [dependencies.pyo3]
 version = "0.8.5"

--- a/src/dag_isomorphism.rs
+++ b/src/dag_isomorphism.rs
@@ -1,0 +1,562 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// This module is a forked version of petgraph's isomorphism module @ 0.5.0.
+// It has then been modified to function with PyDAG inputs instead of Graph.
+
+use fixedbitset::FixedBitSet;
+use std::marker;
+
+use super::PyDAG;
+
+use pyo3::prelude::*;
+
+use petgraph::stable_graph::NodeIndex;
+use petgraph::visit::GetAdjacencyMatrix;
+use petgraph::{Directed, Incoming};
+
+#[derive(Debug)]
+struct Vf2State {
+    /// The current mapping M(s) of nodes from G0 → G1 and G1 → G0,
+    /// NodeIndex::end() for no mapping.
+    mapping: Vec<NodeIndex>,
+    /// out[i] is non-zero if i is in either M_0(s) or Tout_0(s)
+    /// These are all the next vertices that are not mapped yet, but
+    /// have an outgoing edge from the mapping.
+    out: Vec<usize>,
+    /// ins[i] is non-zero if i is in either M_0(s) or Tin_0(s)
+    /// These are all the incoming vertices, those not mapped yet, but
+    /// have an edge from them into the mapping.
+    /// Unused if graph is undirected -- it's identical with out in that case.
+    ins: Vec<usize>,
+    out_size: usize,
+    ins_size: usize,
+    adjacency_matrix: FixedBitSet,
+    generation: usize,
+    _etype: marker::PhantomData<Directed>,
+}
+
+impl Vf2State {
+    pub fn new(dag: &PyDAG) -> Self {
+        let g = &dag.graph;
+        let c0 = g.node_count();
+        let mut state = Vf2State {
+            mapping: Vec::with_capacity(c0),
+            out: Vec::with_capacity(c0),
+            ins: Vec::with_capacity(c0 * (g.is_directed() as usize)),
+            out_size: 0,
+            ins_size: 0,
+            adjacency_matrix: g.adjacency_matrix(),
+            generation: 0,
+            _etype: marker::PhantomData,
+        };
+        for _ in 0..c0 {
+            state.mapping.push(NodeIndex::end());
+            state.out.push(0);
+            state.ins.push(0);
+        }
+        state
+    }
+
+    /// Return **true** if we have a complete mapping
+    pub fn is_complete(&self) -> bool {
+        self.generation == self.mapping.len()
+    }
+
+    /// Add mapping **from** <-> **to** to the state.
+    pub fn push_mapping(
+        &mut self,
+        from: NodeIndex,
+        to: NodeIndex,
+        dag: &PyDAG,
+    ) {
+        let g = &dag.graph;
+        self.generation += 1;
+        let s = self.generation;
+        self.mapping[from.index()] = to;
+        // update T0 & T1 ins/outs
+        // T0out: Node in G0 not in M0 but successor of a node in M0.
+        // st.out[0]: Node either in M0 or successor of M0
+        for ix in g.neighbors(from) {
+            if self.out[ix.index()] == 0 {
+                self.out[ix.index()] = s;
+                self.out_size += 1;
+            }
+        }
+        if g.is_directed() {
+            for ix in g.neighbors_directed(from, Incoming) {
+                if self.ins[ix.index()] == 0 {
+                    self.ins[ix.index()] = s;
+                    self.ins_size += 1;
+                }
+            }
+        }
+    }
+
+    /// Restore the state to before the last added mapping
+    pub fn pop_mapping(&mut self, from: NodeIndex, dag: &PyDAG) {
+        let g = &dag.graph;
+        let s = self.generation;
+        self.generation -= 1;
+
+        // undo (n, m) mapping
+        self.mapping[from.index()] = NodeIndex::end();
+
+        // unmark in ins and outs
+        for ix in g.neighbors(from) {
+            if self.out[ix.index()] == s {
+                self.out[ix.index()] = 0;
+                self.out_size -= 1;
+            }
+        }
+        if g.is_directed() {
+            for ix in g.neighbors_directed(from, Incoming) {
+                if self.ins[ix.index()] == s {
+                    self.ins[ix.index()] = 0;
+                    self.ins_size -= 1;
+                }
+            }
+        }
+    }
+
+    /// Find the next (least) node in the Tout set.
+    pub fn next_out_index(&self, from_index: usize) -> Option<usize> {
+        self.out[from_index..]
+            .iter()
+            .enumerate()
+            .find(move |&(index, elt)| {
+                *elt > 0 && self.mapping[from_index + index] == NodeIndex::end()
+            })
+            .map(|(index, _)| index)
+    }
+
+    /// Find the next (least) node in the Tin set.
+    pub fn next_in_index(&self, from_index: usize) -> Option<usize> {
+        self.ins[from_index..]
+            .iter()
+            .enumerate()
+            .find(move |&(index, elt)| {
+                *elt > 0 && self.mapping[from_index + index] == NodeIndex::end()
+            })
+            .map(|(index, _)| index)
+    }
+
+    /// Find the next (least) node in the N - M set.
+    pub fn next_rest_index(&self, from_index: usize) -> Option<usize> {
+        self.mapping[from_index..]
+            .iter()
+            .enumerate()
+            .find(|&(_, elt)| *elt == NodeIndex::end())
+            .map(|(index, _)| index)
+    }
+}
+
+/// [Graph] Return `true` if the graphs `g0` and `g1` are isomorphic.
+///
+/// Using the VF2 algorithm, only matching graph syntactically (graph
+/// structure).
+///
+/// The graphs should not be multigraphs.
+///
+/// **Reference**
+///
+/// * Luigi P. Cordella, Pasquale Foggia, Carlo Sansone, Mario Vento;
+///   *A (Sub)Graph Isomorphism Algorithm for Matching Large Graphs*
+pub fn is_isomorphic(dag0: &PyDAG, dag1: &PyDAG) -> bool {
+    let g0 = &dag0.graph;
+    let g1 = &dag1.graph;
+    if g0.node_count() != g1.node_count() || g0.edge_count() != g1.edge_count()
+    {
+        return false;
+    }
+
+    let mut st = [Vf2State::new(dag0), Vf2State::new(dag1)];
+    try_match(
+        &mut st,
+        dag0,
+        dag1,
+        &mut NoSemanticMatch,
+        &mut NoSemanticMatch,
+    )
+    .unwrap_or(false)
+}
+
+/// [Graph] Return `true` if the graphs `g0` and `g1` are isomorphic.
+///
+/// Using the VF2 algorithm, examining both syntactic and semantic
+/// graph isomorphism (graph structure and matching node and edge weights).
+///
+/// The graphs should not be multigraphs.
+pub fn is_isomorphic_matching<F, G>(
+    dag0: &PyDAG,
+    dag1: &PyDAG,
+    mut node_match: F,
+    mut edge_match: G,
+) -> bool
+where
+    F: FnMut(&PyObject, &PyObject) -> bool,
+    G: FnMut(&PyObject, &PyObject) -> bool,
+{
+    let g0 = &dag0.graph;
+    let g1 = &dag1.graph;
+    if g0.node_count() != g1.node_count() || g0.edge_count() != g1.edge_count()
+    {
+        return false;
+    }
+
+    let mut st = [Vf2State::new(dag0), Vf2State::new(dag1)];
+    try_match(&mut st, dag0, dag1, &mut node_match, &mut edge_match)
+        .unwrap_or(false)
+}
+
+trait SemanticMatcher<T> {
+    fn enabled() -> bool;
+    fn eq(&mut self, _: &T, _: &T) -> bool;
+}
+
+struct NoSemanticMatch;
+
+impl<T> SemanticMatcher<T> for NoSemanticMatch {
+    #[inline]
+    fn enabled() -> bool {
+        false
+    }
+    #[inline]
+    fn eq(&mut self, _: &T, _: &T) -> bool {
+        true
+    }
+}
+
+impl<T, F> SemanticMatcher<T> for F
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    #[inline]
+    fn enabled() -> bool {
+        true
+    }
+    #[inline]
+    fn eq(&mut self, a: &T, b: &T) -> bool {
+        self(a, b)
+    }
+}
+
+/// Return Some(bool) if isomorphism is decided, else None.
+fn try_match<F, G>(
+    mut st: &mut [Vf2State; 2],
+    dag0: &PyDAG,
+    dag1: &PyDAG,
+    node_match: &mut F,
+    edge_match: &mut G,
+) -> Option<bool>
+where
+    F: SemanticMatcher<PyObject>,
+    G: SemanticMatcher<PyObject>,
+{
+    let g0 = &dag0.graph;
+    let g1 = &dag1.graph;
+    if st[0].is_complete() {
+        return Some(true);
+    }
+    let dag = [dag0, dag1];
+    let g = [g0, g1];
+    let graph_indices = 0..2;
+    let end = NodeIndex::end();
+
+    // A "depth first" search of a valid mapping from graph 1 to graph 2
+
+    // F(s, n, m) -- evaluate state s and add mapping n <-> m
+
+    // Find least T1out node (in st.out[1] but not in M[1])
+    #[derive(Copy, Clone, PartialEq, Debug)]
+    enum OpenList {
+        Out,
+        In,
+        Other,
+    }
+
+    #[derive(Clone, PartialEq, Debug)]
+    enum Frame<N: marker::Copy> {
+        Outer,
+        Inner { nodes: [N; 2], open_list: OpenList },
+        Unwind { nodes: [N; 2], open_list: OpenList },
+    }
+
+    let next_candidate =
+        |st: &mut [Vf2State; 2]| -> Option<(NodeIndex, NodeIndex, OpenList)> {
+            let mut to_index;
+            let mut from_index = None;
+            let mut open_list = OpenList::Out;
+            // Try the out list
+            to_index = st[1].next_out_index(0);
+
+            if to_index.is_some() {
+                from_index = st[0].next_out_index(0);
+                open_list = OpenList::Out;
+            }
+            // Try the in list
+            if to_index.is_none() || from_index.is_none() {
+                to_index = st[1].next_in_index(0);
+
+                if to_index.is_some() {
+                    from_index = st[0].next_in_index(0);
+                    open_list = OpenList::In;
+                }
+            }
+            // Try the other list -- disconnected graph
+            if to_index.is_none() || from_index.is_none() {
+                to_index = st[1].next_rest_index(0);
+                if to_index.is_some() {
+                    from_index = st[0].next_rest_index(0);
+                    open_list = OpenList::Other;
+                }
+            }
+            match (from_index, to_index) {
+                (Some(n), Some(m)) => {
+                    Some((NodeIndex::new(n), NodeIndex::new(m), open_list))
+                }
+                // No more candidates
+                _ => None,
+            }
+        };
+    let next_from_ix = |st: &mut [Vf2State; 2],
+                        nx: NodeIndex,
+                        open_list: OpenList|
+     -> Option<NodeIndex> {
+        // Find the next node index to try on the `from` side of the mapping
+        let start = nx.index() + 1;
+        let cand0 = match open_list {
+            OpenList::Out => st[0].next_out_index(start),
+            OpenList::In => st[0].next_in_index(start),
+            OpenList::Other => st[0].next_rest_index(start),
+        }
+        .map(|c| c + start); // compensate for start offset.
+        match cand0 {
+            None => None, // no more candidates
+            Some(ix) => {
+                debug_assert!(ix >= start);
+                Some(NodeIndex::new(ix))
+            }
+        }
+    };
+    //fn pop_state(nodes: [NodeIndex<Ix>; 2]) {
+    let pop_state = |st: &mut [Vf2State; 2], nodes: [NodeIndex; 2]| {
+        // Restore state.
+        for j in graph_indices.clone() {
+            st[j].pop_mapping(nodes[j], dag[j]);
+        }
+    };
+    //fn push_state(nodes: [NodeIndex<Ix>; 2]) {
+    let push_state = |st: &mut [Vf2State; 2], nodes: [NodeIndex; 2]| {
+        // Add mapping nx <-> mx to the state
+        for j in graph_indices.clone() {
+            st[j].push_mapping(nodes[j], nodes[1 - j], dag[j]);
+        }
+    };
+    //fn is_feasible(nodes: [NodeIndex<Ix>; 2]) -> bool {
+    let mut is_feasible = |st: &mut [Vf2State; 2],
+                           nodes: [NodeIndex; 2]|
+     -> bool {
+        // Check syntactic feasibility of mapping by ensuring adjacencies
+        // of nx map to adjacencies of mx.
+        //
+        // nx == map to => mx
+        //
+        // R_succ
+        //
+        // Check that every neighbor of nx is mapped to a neighbor of mx,
+        // then check the reverse, from mx to nx. Check that they have the same
+        // count of edges.
+        //
+        // Note: We want to check the lookahead measures here if we can,
+        // R_out: Equal for G0, G1: Card(Succ(G, n) ^ Tout); for both Succ and Pred
+        // R_in: Same with Tin
+        // R_new: Equal for G0, G1: Ñ n Pred(G, n); both Succ and Pred,
+        //      Ñ is G0 - M - Tin - Tout
+        // last attempt to add these did not speed up any of the testcases
+        let mut succ_count = [0, 0];
+        for j in graph_indices.clone() {
+            for n_neigh in g[j].neighbors(nodes[j]) {
+                succ_count[j] += 1;
+                // handle the self loop case; it's not in the mapping (yet)
+                let m_neigh = if nodes[j] != n_neigh {
+                    st[j].mapping[n_neigh.index()]
+                } else {
+                    nodes[1 - j]
+                };
+                if m_neigh == end {
+                    continue;
+                }
+                let has_edge = g[1 - j].is_adjacent(
+                    &st[1 - j].adjacency_matrix,
+                    nodes[1 - j],
+                    m_neigh,
+                );
+                if !has_edge {
+                    return false;
+                }
+            }
+        }
+        if succ_count[0] != succ_count[1] {
+            return false;
+        }
+        // R_pred
+        if g[0].is_directed() {
+            let mut pred_count = [0, 0];
+            for j in graph_indices.clone() {
+                for n_neigh in g[j].neighbors_directed(nodes[j], Incoming) {
+                    pred_count[j] += 1;
+                    // the self loop case is handled in outgoing
+                    let m_neigh = st[j].mapping[n_neigh.index()];
+                    if m_neigh == end {
+                        continue;
+                    }
+                    let has_edge = g[1 - j].is_adjacent(
+                        &st[1 - j].adjacency_matrix,
+                        m_neigh,
+                        nodes[1 - j],
+                    );
+                    if !has_edge {
+                        return false;
+                    }
+                }
+            }
+            if pred_count[0] != pred_count[1] {
+                return false;
+            }
+        }
+        // semantic feasibility: compare associated data for nodes
+        if F::enabled() && !node_match.eq(&g[0][nodes[0]], &g[1][nodes[1]]) {
+            return false;
+        }
+        // semantic feasibility: compare associated data for edges
+        if G::enabled() {
+            // outgoing edges
+            for j in graph_indices.clone() {
+                let mut edges = g[j].neighbors(nodes[j]).detach();
+                while let Some((n_edge, n_neigh)) = edges.next(g[j]) {
+                    // handle the self loop case; it's not in the mapping (yet)
+                    let m_neigh = if nodes[j] != n_neigh {
+                        st[j].mapping[n_neigh.index()]
+                    } else {
+                        nodes[1 - j]
+                    };
+                    if m_neigh == end {
+                        continue;
+                    }
+                    match g[1 - j].find_edge(nodes[1 - j], m_neigh) {
+                        Some(m_edge) => {
+                            if !edge_match.eq(&g[j][n_edge], &g[1 - j][m_edge])
+                            {
+                                return false;
+                            }
+                        }
+                        None => unreachable!(), // covered by syntactic check
+                    }
+                }
+            }
+            // incoming edges
+            if g[0].is_directed() {
+                for j in graph_indices.clone() {
+                    let mut edges =
+                        g[j].neighbors_directed(nodes[j], Incoming).detach();
+                    while let Some((n_edge, n_neigh)) = edges.next(g[j]) {
+                        // the self loop case is handled in outgoing
+                        let m_neigh = st[j].mapping[n_neigh.index()];
+                        if m_neigh == end {
+                            continue;
+                        }
+                        match g[1 - j].find_edge(m_neigh, nodes[1 - j]) {
+                            Some(m_edge) => {
+                                if !edge_match
+                                    .eq(&g[j][n_edge], &g[1 - j][m_edge])
+                                {
+                                    return false;
+                                }
+                            }
+                            None => unreachable!(), // covered by syntactic check
+                        }
+                    }
+                }
+            }
+        }
+        true
+    };
+    let mut stack: Vec<Frame<NodeIndex>> = vec![Frame::Outer];
+
+    while let Some(frame) = stack.pop() {
+        match frame {
+            Frame::Unwind {
+                nodes,
+                open_list: ol,
+            } => {
+                pop_state(&mut st, nodes);
+
+                match next_from_ix(&mut st, nodes[0], ol) {
+                    None => continue,
+                    Some(nx) => {
+                        let f = Frame::Inner {
+                            nodes: [nx, nodes[1]],
+                            open_list: ol,
+                        };
+                        stack.push(f);
+                    }
+                }
+            }
+            Frame::Outer => match next_candidate(&mut st) {
+                None => continue,
+                Some((nx, mx, ol)) => {
+                    let f = Frame::Inner {
+                        nodes: [nx, mx],
+                        open_list: ol,
+                    };
+                    stack.push(f);
+                }
+            },
+            Frame::Inner {
+                nodes,
+                open_list: ol,
+            } => {
+                if is_feasible(&mut st, nodes) {
+                    push_state(&mut st, nodes);
+                    if st[0].is_complete() {
+                        return Some(true);
+                    }
+                    // Check cardinalities of Tin, Tout sets
+                    if st[0].out_size == st[1].out_size
+                        && st[0].ins_size == st[1].ins_size
+                    {
+                        let f0 = Frame::Unwind {
+                            nodes,
+                            open_list: ol,
+                        };
+                        stack.push(f0);
+                        stack.push(Frame::Outer);
+                        continue;
+                    }
+                    pop_state(&mut st, nodes);
+                }
+                match next_from_ix(&mut st, nodes[0], ol) {
+                    None => continue,
+                    Some(nx) => {
+                        let f = Frame::Inner {
+                            nodes: [nx, nodes[1]],
+                            open_list: ol,
+                        };
+                        stack.push(f);
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,12 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-extern crate pyo3;
-
-extern crate daggy;
 extern crate petgraph;
+extern crate pyo3;
 
 use std::collections::HashMap;
 use std::iter;
+use std::ops::{Index, IndexMut};
 
 use pyo3::create_exception;
 use pyo3::exceptions::Exception;
@@ -25,18 +24,195 @@ use pyo3::types::{PyDict, PyList};
 use pyo3::wrap_pyfunction;
 use pyo3::Python;
 
-use daggy::Dag;
-use daggy::EdgeIndex;
-use daggy::NodeIndex;
-use daggy::Walker;
 use petgraph::algo;
-use petgraph::visit::EdgeRef;
-use petgraph::visit::IntoNeighbors;
-use petgraph::visit::IntoNeighborsDirected;
+use petgraph::graph::{EdgeIndex, NodeIndex};
+use petgraph::prelude::*;
+use petgraph::stable_graph::StableDiGraph;
+use petgraph::visit::{
+    GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
+    IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected,
+    IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable, NodeCount,
+    NodeIndexable, Visitable,
+};
 
 #[pyclass]
 pub struct PyDAG {
-    graph: Dag<PyObject, PyObject>,
+    graph: StableDiGraph<PyObject, PyObject>,
+}
+
+pub type Edges<'a, E> =
+    petgraph::stable_graph::Edges<'a, E, petgraph::Directed>;
+
+impl GraphBase for PyDAG {
+    type NodeId = NodeIndex;
+    type EdgeId = EdgeIndex;
+}
+
+impl NodeCount for PyDAG {
+    fn node_count(&self) -> usize {
+        self.graph.node_count()
+    }
+}
+
+impl GraphProp for PyDAG {
+    type EdgeType = petgraph::Directed;
+    fn is_directed(&self) -> bool {
+        true
+    }
+}
+
+impl petgraph::visit::Visitable for PyDAG {
+    type Map = <StableDiGraph<PyObject, PyObject> as Visitable>::Map;
+    fn visit_map(&self) -> Self::Map {
+        self.graph.visit_map()
+    }
+    fn reset_map(&self, map: &mut Self::Map) {
+        self.graph.reset_map(map)
+    }
+}
+
+impl petgraph::visit::Data for PyDAG {
+    type NodeWeight = PyObject;
+    type EdgeWeight = PyObject;
+}
+
+impl petgraph::data::DataMap for PyDAG {
+    fn node_weight(&self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
+        self.graph.node_weight(id)
+    }
+    fn edge_weight(&self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
+        self.graph.edge_weight(id)
+    }
+}
+
+impl petgraph::data::DataMapMut for PyDAG {
+    fn node_weight_mut(
+        &mut self,
+        id: Self::NodeId,
+    ) -> Option<&mut Self::NodeWeight> {
+        self.graph.node_weight_mut(id)
+    }
+    fn edge_weight_mut(
+        &mut self,
+        id: Self::EdgeId,
+    ) -> Option<&mut Self::EdgeWeight> {
+        self.graph.edge_weight_mut(id)
+    }
+}
+
+impl<'a> IntoNeighbors for &'a PyDAG {
+    type Neighbors = petgraph::stable_graph::Neighbors<'a, PyObject>;
+    fn neighbors(self, n: NodeIndex) -> Self::Neighbors {
+        self.graph.neighbors(n)
+    }
+}
+
+impl<'a> IntoNeighborsDirected for &'a PyDAG {
+    type NeighborsDirected = petgraph::stable_graph::Neighbors<'a, PyObject>;
+    fn neighbors_directed(
+        self,
+        n: NodeIndex,
+        d: petgraph::Direction,
+    ) -> Self::Neighbors {
+        self.graph.neighbors_directed(n, d)
+    }
+}
+
+impl<'a> IntoEdgeReferences for &'a PyDAG {
+    type EdgeRef = petgraph::stable_graph::EdgeReference<'a, PyObject>;
+    type EdgeReferences = petgraph::stable_graph::EdgeReferences<'a, PyObject>;
+    fn edge_references(self) -> Self::EdgeReferences {
+        self.graph.edge_references()
+    }
+}
+
+impl<'a> IntoEdges for &'a PyDAG {
+    type Edges = Edges<'a, PyObject>;
+    fn edges(self, a: Self::NodeId) -> Self::Edges {
+        self.graph.edges(a)
+    }
+}
+
+impl<'a> IntoEdgesDirected for &'a PyDAG {
+    type EdgesDirected = Edges<'a, PyObject>;
+    fn edges_directed(
+        self,
+        a: Self::NodeId,
+        dir: petgraph::Direction,
+    ) -> Self::EdgesDirected {
+        self.graph.edges_directed(a, dir)
+    }
+}
+
+impl<'a> IntoNodeIdentifiers for &'a PyDAG {
+    type NodeIdentifiers = petgraph::stable_graph::NodeIndices<'a, PyObject>;
+    fn node_identifiers(self) -> Self::NodeIdentifiers {
+        self.graph.node_identifiers()
+    }
+}
+
+impl<'a> IntoNodeReferences for &'a PyDAG {
+    type NodeRef = (NodeIndex, &'a PyObject);
+    type NodeReferences = petgraph::stable_graph::NodeReferences<'a, PyObject>;
+    fn node_references(self) -> Self::NodeReferences {
+        self.graph.node_references()
+    }
+}
+
+impl NodeIndexable for PyDAG {
+    fn node_bound(&self) -> usize {
+        self.graph.node_bound()
+    }
+    fn to_index(&self, ix: NodeIndex) -> usize {
+        self.graph.to_index(ix)
+    }
+    fn from_index(&self, ix: usize) -> Self::NodeId {
+        self.graph.from_index(ix)
+    }
+}
+
+impl NodeCompactIndexable for PyDAG {}
+
+impl Index<NodeIndex> for PyDAG {
+    type Output = PyObject;
+    fn index(&self, index: NodeIndex) -> &PyObject {
+        &self.graph[index]
+    }
+}
+
+impl IndexMut<NodeIndex> for PyDAG {
+    fn index_mut(&mut self, index: NodeIndex) -> &mut PyObject {
+        &mut self.graph[index]
+    }
+}
+
+impl Index<EdgeIndex> for PyDAG {
+    type Output = PyObject;
+    fn index(&self, index: EdgeIndex) -> &PyObject {
+        &self.graph[index]
+    }
+}
+
+impl IndexMut<EdgeIndex> for PyDAG {
+    fn index_mut(&mut self, index: EdgeIndex) -> &mut PyObject {
+        &mut self.graph[index]
+    }
+}
+
+impl GetAdjacencyMatrix for PyDAG {
+    type AdjMatrix =
+        <StableDiGraph<PyObject, PyObject> as GetAdjacencyMatrix>::AdjMatrix;
+    fn adjacency_matrix(&self) -> Self::AdjMatrix {
+        self.graph.adjacency_matrix()
+    }
+    fn is_adjacent(
+        &self,
+        matrix: &Self::AdjMatrix,
+        a: NodeIndex,
+        b: NodeIndex,
+    ) -> bool {
+        self.graph.is_adjacent(matrix, a, b)
+    }
 }
 
 #[pymethods]
@@ -44,44 +220,48 @@ impl PyDAG {
     #[new]
     fn new(obj: &PyRawObject) {
         obj.init(PyDAG {
-            graph: Dag::<PyObject, PyObject>::new(),
+            graph: StableDiGraph::<PyObject, PyObject>::new(),
         });
     }
 
     pub fn edges(&self, py: Python) -> PyObject {
-        let raw_edges = self.graph.raw_edges();
+        let raw_edges = self.graph.edge_indices();
         let mut out: Vec<&PyObject> = Vec::new();
         for edge in raw_edges {
-            out.push(&edge.weight);
+            out.push(self.graph.edge_weight(edge).unwrap());
         }
         PyList::new(py, out).into()
     }
 
     pub fn nodes(&self, py: Python) -> PyObject {
-        let raw_nodes = self.graph.raw_nodes();
+        let raw_nodes = self.graph.node_indices();
         let mut out: Vec<&PyObject> = Vec::new();
         for node in raw_nodes {
-            out.push(&node.weight);
+            out.push(self.graph.node_weight(node).unwrap());
         }
         PyList::new(py, out).into()
     }
 
     pub fn successors(&self, py: Python, node: usize) -> PyResult<PyObject> {
         let index = NodeIndex::new(node);
-        let c_walker = self.graph.children(index);
+        let children = self
+            .graph
+            .neighbors_directed(index, petgraph::Direction::Outgoing);
         let mut succesors: Vec<&PyObject> = Vec::new();
-        for succ in c_walker.iter(&self.graph) {
-            succesors.push(self.graph.node_weight(succ.1).unwrap());
+        for succ in children {
+            succesors.push(self.graph.node_weight(succ).unwrap());
         }
         Ok(PyList::new(py, succesors).into())
     }
 
     pub fn predecessors(&self, py: Python, node: usize) -> PyResult<PyObject> {
         let index = NodeIndex::new(node);
-        let p_walker = self.graph.parents(index);
+        let parents = self
+            .graph
+            .neighbors_directed(index, petgraph::Direction::Incoming);
         let mut predec: Vec<&PyObject> = Vec::new();
-        for pred in p_walker.iter(&self.graph) {
-            predec.push(self.graph.node_weight(pred.1).unwrap());
+        for pred in parents {
+            predec.push(self.graph.node_weight(pred).unwrap());
         }
         Ok(PyList::new(py, predec).into())
     }
@@ -116,7 +296,6 @@ impl PyDAG {
         let index_b = NodeIndex::new(node_b);
         let raw_edges = self
             .graph
-            .graph()
             .edges_directed(index_a, petgraph::Direction::Outgoing);
         let mut out: Vec<&PyObject> = Vec::new();
         for edge in raw_edges {
@@ -124,7 +303,7 @@ impl PyDAG {
                 out.push(edge.weight());
             }
         }
-        if out.len() == 0 {
+        if out.is_empty() {
             Err(NoEdgeBetweenNodes::py_err("No edge found between nodes"))
         } else {
             Ok(PyList::new(py, out).into())
@@ -146,11 +325,14 @@ impl PyDAG {
     ) -> PyResult<()> {
         let p_index = NodeIndex::new(parent);
         let c_index = NodeIndex::new(child);
-        match self.graph.add_edge(p_index, c_index, edge) {
-            Err(_err) => {
-                Err(DAGWouldCycle::py_err("Adding an edge would cycle"))
-            }
-            Ok(_result) => Ok(()),
+        let edge = self.graph.add_edge(p_index, c_index, edge);
+        // NOTE(mtreinish): This becomes a scaling limit as the dag grows:
+        let cycle = algo::is_cyclic_directed(&self.graph);
+        if cycle {
+            self.graph.remove_edge(edge);
+            Err(DAGWouldCycle::py_err("Adding an edge would cycle"))
+        } else {
+            Ok(())
         }
     }
 
@@ -175,19 +357,35 @@ impl PyDAG {
         Ok(())
     }
 
-    pub fn add_node(&mut self, obj: PyObject) -> usize {
+    pub fn add_node(&mut self, obj: PyObject) -> PyResult<usize> {
         let index = self.graph.add_node(obj);
-        index.index()
+        // NOTE(mtreinish): This becomes a scaling limit as the dag grows:
+        let cycle = algo::is_cyclic_directed(&self.graph);
+        if cycle {
+            self.graph.remove_node(index);
+            Err(DAGWouldCycle::py_err("Adding an edge would cycle"))
+        } else {
+            Ok(index.index())
+        }
     }
+
     pub fn add_child(
         &mut self,
         parent: usize,
         obj: PyObject,
         edge: PyObject,
-    ) -> usize {
+    ) -> PyResult<usize> {
         let index = NodeIndex::new(parent);
-        let (_, index) = self.graph.add_child(index, edge, obj);
-        index.index()
+        let child_node = self.graph.add_node(obj);
+        let _child_edge = self.graph.add_edge(index, child_node, edge);
+        // NOTE(mtreinish): This becomes a scaling limit as the dag grows:
+        let cycle = algo::is_cyclic_directed(&self.graph);
+        if cycle {
+            self.graph.remove_node(index);
+            Err(DAGWouldCycle::py_err("Adding an edge would cycle"))
+        } else {
+            Ok(child_node.index())
+        }
     }
 
     pub fn add_parent(
@@ -195,24 +393,31 @@ impl PyDAG {
         child: usize,
         obj: PyObject,
         edge: PyObject,
-    ) -> usize {
+    ) -> PyResult<usize> {
         let index = NodeIndex::new(child);
-        let (_, index) = self.graph.add_parent(index, edge, obj);
-        index.index()
+        let parent_node = self.graph.add_node(obj);
+        let _parent_edge = self.graph.add_edge(parent_node, index, edge);
+        // NOTE(mtreinish): This becomes a scaling limit as the dag grows:
+        let cycle = algo::is_cyclic_directed(&self.graph);
+        if cycle {
+            self.graph.remove_node(index);
+            Err(DAGWouldCycle::py_err("Adding an edge would cycle"))
+        } else {
+            Ok(parent_node.index())
+        }
     }
 
     pub fn adj(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
         let index = NodeIndex::new(node);
         let neighbors = self.graph.neighbors(index);
         let out_dict = PyDict::new(py);
-        let graph = self.graph.graph();
         for neighbor in neighbors {
-            let mut edge = graph.find_edge(index, neighbor);
+            let mut edge = self.graph.find_edge(index, neighbor);
             // If there is no edge then it must be a parent neighbor
             if edge.is_none() {
-                edge = graph.find_edge(neighbor, index);
+                edge = self.graph.find_edge(neighbor, index);
             }
-            let edge_w = graph.edge_weight(edge.unwrap());
+            let edge_w = self.graph.edge_weight(edge.unwrap());
             out_dict.set_item(neighbor.index(), edge_w)?;
         }
         Ok(out_dict.into())
@@ -225,37 +430,34 @@ impl PyDAG {
         direction: bool,
     ) -> PyResult<PyObject> {
         let index = NodeIndex::new(node);
-        let dir;
-        if direction {
-            dir = petgraph::Direction::Incoming;
+        let dir = if direction {
+            petgraph::Direction::Incoming
         } else {
-            dir = petgraph::Direction::Outgoing;
-        }
-        let graph = self.graph.graph();
+            petgraph::Direction::Outgoing
+        };
         let neighbors = self.graph.neighbors_directed(index, dir);
         let out_dict = PyDict::new(py);
         for neighbor in neighbors {
-            let edge;
-            if direction {
-                edge = match graph.find_edge(neighbor, index) {
+            let edge = if direction {
+                match self.graph.find_edge(neighbor, index) {
                     Some(edge) => edge,
                     None => {
                         return Err(NoEdgeBetweenNodes::py_err(
                             "No edge found between nodes",
                         ))
                     }
-                };
+                }
             } else {
-                edge = match graph.find_edge(index, neighbor) {
+                match self.graph.find_edge(index, neighbor) {
                     Some(edge) => edge,
                     None => {
                         return Err(NoEdgeBetweenNodes::py_err(
                             "No edge found between nodes",
                         ))
                     }
-                };
-            }
-            let edge_w = graph.edge_weight(edge);
+                }
+            };
+            let edge_w = self.graph.edge_weight(edge);
             out_dict.set_item(neighbor.index(), edge_w)?;
         }
         Ok(out_dict.into())
@@ -291,21 +493,22 @@ where
 #[pyfunction]
 fn dag_longest_path_length(graph: &PyDAG) -> PyResult<usize> {
     let dag = &graph.graph;
-    let nodes = match algo::toposort(dag.graph(), None) {
+    let nodes = match algo::toposort(graph, None) {
         Ok(nodes) => nodes,
         Err(_err) => {
             return Err(DAGHasCycle::py_err("Sort encountered a cycle"))
         }
     };
-    if nodes.len() == 0 {
+    if nodes.is_empty() {
         return Ok(0);
     }
     let mut dist: HashMap<usize, (usize, usize)> = HashMap::new();
     for node in nodes {
         // Iterator that yields (EdgeIndex, NodeIndex)
-        let parents = dag.parents(node).iter(&dag);
+        let parents =
+            dag.neighbors_directed(node, petgraph::Direction::Incoming);
         let mut us: Vec<(usize, usize)> = Vec::new();
-        for (_, p_node) in parents {
+        for p_node in parents {
             let p_index = p_node.index();
             let length = dist[&p_index].0 + 1;
             let u = p_index;
@@ -347,41 +550,40 @@ fn dag_longest_path_length(graph: &PyDAG) -> PyResult<usize> {
 
 #[pyfunction]
 fn number_weakly_connected_components(graph: &PyDAG) -> usize {
-    let dag = graph.graph.graph();
-    algo::connected_components(dag)
+    algo::connected_components(graph)
 }
 
-#[pyfunction]
-fn is_isomorphic(first: &PyDAG, second: &PyDAG) -> bool {
-    algo::is_isomorphic(first.graph.graph(), second.graph.graph())
-}
+//#[pyfunction]
+//fn is_isomorphic(first: &PyDAG, second: &PyDAG) -> bool {
+//    is_isomorphic(&first.graph, &second.graph)
+//}
 
-#[pyfunction]
-fn is_isomorphic_node_match(
-    py: Python,
-    first: &PyDAG,
-    second: &PyDAG,
-    matcher: PyObject,
-) -> bool {
-    let compare_nodes = |a: &PyObject, b: &PyObject| -> bool {
-        let res = matcher.call1(py, (a, b)).unwrap();
-        res.is_true(py).unwrap()
-    };
-
-    fn compare_edges(_a: &PyObject, _b: &PyObject) -> bool {
-        true
-    }
-    algo::is_isomorphic_matching(
-        first.graph.graph(),
-        second.graph.graph(),
-        compare_nodes,
-        compare_edges,
-    )
-}
+//#[pyfunction]
+//fn is_isomorphic_node_match(
+//    py: Python,
+//    first: &PyDAG,
+//    second: &PyDAG,
+//    matcher: PyObject,
+//) -> bool {
+//    let compare_nodes = |a: &PyObject, b: &PyObject| -> bool {
+//        let res = matcher.call1(py, (a, b)).unwrap();
+//        res.is_true(py).unwrap()
+//    };
+//
+//    fn compare_edges(_a: &PyObject, _b: &PyObject) -> bool {
+//        true
+//    }
+//    algo::is_isomorphic_matching(
+//        &first.graph,
+//        &second.graph,
+//        compare_nodes,
+//        compare_edges,
+//    )
+//}
 
 #[pyfunction]
 fn topological_sort(py: Python, graph: &PyDAG) -> PyResult<PyObject> {
-    let nodes = match algo::toposort(graph.graph.graph(), None) {
+    let nodes = match algo::toposort(graph, None) {
         Ok(nodes) => nodes,
         Err(_err) => {
             return Err(DAGHasCycle::py_err("Sort encountered a cycle"))
@@ -405,8 +607,8 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_wrapped(wrap_pyfunction!(dag_longest_path_length))?;
     m.add_wrapped(wrap_pyfunction!(number_weakly_connected_components))?;
-    m.add_wrapped(wrap_pyfunction!(is_isomorphic))?;
-    m.add_wrapped(wrap_pyfunction!(is_isomorphic_node_match))?;
+    //    m.add_wrapped(wrap_pyfunction!(is_isomorphic))?;
+    //    m.add_wrapped(wrap_pyfunction!(is_isomorphic_node_match))?;
     m.add_wrapped(wrap_pyfunction!(topological_sort))?;
     //    m.add_wrapped(wrap_pyfunction!(lexicographical_topological_sort))?;
     m.add_class::<PyDAG>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,11 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+extern crate fixedbitset;
 extern crate petgraph;
 extern crate pyo3;
+
+mod dag_isomorphism;
 
 use std::collections::HashMap;
 use std::iter;
@@ -557,33 +560,33 @@ fn is_directed_acyclic_graph(graph: &PyDAG) -> bool {
     !cycle_detected
 }
 
-//#[pyfunction]
-//fn is_isomorphic(first: &PyDAG, second: &PyDAG) -> bool {
-//    is_isomorphic(&first.graph, &second.graph)
-//}
+#[pyfunction]
+fn is_isomorphic(first: &PyDAG, second: &PyDAG) -> bool {
+    dag_isomorphism::is_isomorphic(first, second)
+}
 
-//#[pyfunction]
-//fn is_isomorphic_node_match(
-//    py: Python,
-//    first: &PyDAG,
-//    second: &PyDAG,
-//    matcher: PyObject,
-//) -> bool {
-//    let compare_nodes = |a: &PyObject, b: &PyObject| -> bool {
-//        let res = matcher.call1(py, (a, b)).unwrap();
-//        res.is_true(py).unwrap()
-//    };
-//
-//    fn compare_edges(_a: &PyObject, _b: &PyObject) -> bool {
-//        true
-//    }
-//    algo::is_isomorphic_matching(
-//        &first.graph,
-//        &second.graph,
-//        compare_nodes,
-//        compare_edges,
-//    )
-//}
+#[pyfunction]
+fn is_isomorphic_node_match(
+    py: Python,
+    first: &PyDAG,
+    second: &PyDAG,
+    matcher: PyObject,
+) -> bool {
+    let compare_nodes = |a: &PyObject, b: &PyObject| -> bool {
+        let res = matcher.call1(py, (a, b)).unwrap();
+        res.is_true(py).unwrap()
+    };
+
+    fn compare_edges(_a: &PyObject, _b: &PyObject) -> bool {
+        true
+    }
+    dag_isomorphism::is_isomorphic_matching(
+        first,
+        second,
+        compare_nodes,
+        compare_edges,
+    )
+}
 
 #[pyfunction]
 fn topological_sort(py: Python, graph: &PyDAG) -> PyResult<PyObject> {
@@ -612,8 +615,8 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(dag_longest_path_length))?;
     m.add_wrapped(wrap_pyfunction!(number_weakly_connected_components))?;
     m.add_wrapped(wrap_pyfunction!(is_directed_acyclic_graph))?;
-    //    m.add_wrapped(wrap_pyfunction!(is_isomorphic))?;
-    //    m.add_wrapped(wrap_pyfunction!(is_isomorphic_node_match))?;
+    m.add_wrapped(wrap_pyfunction!(is_isomorphic))?;
+    m.add_wrapped(wrap_pyfunction!(is_isomorphic_node_match))?;
     m.add_wrapped(wrap_pyfunction!(topological_sort))?;
     //    m.add_wrapped(wrap_pyfunction!(lexicographical_topological_sort))?;
     m.add_class::<PyDAG>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,6 +551,12 @@ fn number_weakly_connected_components(graph: &PyDAG) -> usize {
     algo::connected_components(graph)
 }
 
+#[pyfunction]
+fn is_directed_acyclic_graph(graph: &PyDAG) -> bool {
+    let cycle_detected = algo::is_cyclic_directed(graph);
+    !cycle_detected
+}
+
 //#[pyfunction]
 //fn is_isomorphic(first: &PyDAG, second: &PyDAG) -> bool {
 //    is_isomorphic(&first.graph, &second.graph)
@@ -605,6 +611,7 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_wrapped(wrap_pyfunction!(dag_longest_path_length))?;
     m.add_wrapped(wrap_pyfunction!(number_weakly_connected_components))?;
+    m.add_wrapped(wrap_pyfunction!(is_directed_acyclic_graph))?;
     //    m.add_wrapped(wrap_pyfunction!(is_isomorphic))?;
     //    m.add_wrapped(wrap_pyfunction!(is_isomorphic_node_match))?;
     m.add_wrapped(wrap_pyfunction!(topological_sort))?;

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -93,3 +93,10 @@ class TestEdges(unittest.TestCase):
         node_a = dag.add_node('a')
         dag.remove_edge_from_index(0)
         self.assertEqual([], dag.edges())
+
+    def test_add_cycle(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {})
+        self.assertRaises(Exception, dag.add_edge, node_b,
+                          node_a, {})


### PR DESCRIPTION
This commit migrates the internal graph representation of a PyDAG object
from daggy to use stabledigraph in petgraph directly. This removes an
abstraction layer from the stack and also makes it easier to use the dag
in python since the indexes are stable now. The implementation of the
petgraph traits is borrowed heavily from
https://github.com/mitchmindtree/daggy/pull/21 which added a stable
graph dag implementation to daggy. If/when daggy pushes a new release
that includes this implementation and keeps up to date with the latest
version of petgraph it will probably be worth switching back to that
newer version of daggy. But that can be decided when that happens.

Fixes #6

### TODO:

- [x] Add implementation of petgraph isomorphic functions for stable graphs and update python functions