### PR TITLE
Fix wheel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-#      if: tag IS present
+      if: tag IS present
       script:
         - sudo pip install -U cibuildwheel==1.1.0 twine
         - cibuildwheel --output-dir wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
       install:
           - echo ""
       env:
-        - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && tools/install_rust.sh"
+        - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && yum install -y wget && tools/install_rust.sh"
         - CIBW_SKIP="cp27-* cp34-*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - sudo pip install -U cibuildwheel==1.0.0 twine
+        - sudo pip install -U cibuildwheel==1.1.0 twine
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - os: osx
@@ -106,7 +106,7 @@ jobs:
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       script:
-        - sudo pip2 install -U cibuildwheel==1.0.0 twine
+        - sudo pip2 install -U cibuildwheel==1.1.0 twine
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
+#      if: tag IS present
       script:
         - sudo pip install -U cibuildwheel==1.1.0 twine
         - cibuildwheel --output-dir wheelhouse

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ deploy: false
 skip_branch_with_pr: true
 
 build_script:
-  - if defined WHEEL (pip install cibuildwheel==1.0.0)
+  - if defined WHEEL (pip install cibuildwheel==1.1.0)
   - if defined WHEEL (pip install -U twine)
   - if defined WHEEL (cibuildwheel --output-dir wheelhouse)
   - if defined WHEEL (twine upload wheelhouse\*)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,19 +4,19 @@ environment:
         TARGET: x86_64-pc-windows-msvc
     matrix:
         - PYTHON: C:\Python35-x64
-          TAG_SCENARIO: true
+          TAG_SCENARIO: false
         - PYTHON: C:\Python36-x64
-          TAG_SCENARIO: true
+          TAG_SCENARIO: false
         - PYTHON: C:\Python37-x64
-          TAG_SCENARIO: true
+          TAG_SCENARIO: false
         - PYTHON: C:\Python38-x64
-          TAG_SCENARIO: true
+          TAG_SCENARIO: false
         - WHEEL: 1
           CIBW_BEFORE_BUILD: ps .\tools\setup.ps1 && pip install -U setuptools-rust
           CIBW_SKIP: cp27-* cp34-* *-win32
           TWINE_USERNAME: retworkx-ci
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
-          TAG_SCENARIO: false
+          TAG_SCENARIO: true
 for:
 -
   # non-tagged scenario

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
         - PYTHON: C:\Python38-x64
           TAG_SCENARIO: false
         - WHEEL: 1
-          CIBW_BEFORE_BUILD: ps .\tools\setup.ps1
+          CIBW_BEFORE_BUILD: ps .\tools\setup.ps1 && pip install -U setuptools-rust
           CIBW_SKIP: cp27-* cp34-* *-win32
           TWINE_USERNAME: retworkx-ci
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,19 +4,19 @@ environment:
         TARGET: x86_64-pc-windows-msvc
     matrix:
         - PYTHON: C:\Python35-x64
-          TAG_SCENARIO: false
+          TAG_SCENARIO: true
         - PYTHON: C:\Python36-x64
-          TAG_SCENARIO: false
+          TAG_SCENARIO: true
         - PYTHON: C:\Python37-x64
-          TAG_SCENARIO: false
+          TAG_SCENARIO: true
         - PYTHON: C:\Python38-x64
-          TAG_SCENARIO: false
+          TAG_SCENARIO: true
         - WHEEL: 1
           CIBW_BEFORE_BUILD: ps .\tools\setup.ps1 && pip install -U setuptools-rust
           CIBW_SKIP: cp27-* cp34-* *-win32
           TWINE_USERNAME: retworkx-ci
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
-          TAG_SCENARIO: true
+          TAG_SCENARIO: false
 for:
 -
   # non-tagged scenario

--- a/tools/install_rust.sh
+++ b/tools/install_rust.sh
@@ -1,5 +1,5 @@
 if [ ! -d rust-installer ]; then
     mkdir rust-installer
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rust-installer/rustup.sh
+    wget https://sh.rustup.rs -O rust-installer/rustup.sh
     sh rust-installer/rustup.sh --default-toolchain nightly -y
 fi


### PR DESCRIPTION
The latest 0.1.0 release failed the wheel builds on linux and windows. This was due
to changes in the cibuildwheel project for the 1.0.0 release . It now supports
building with both manylinux1 and manylinux2010. Manylinux2010 includes
a version of curl that no longer has the --proto option which is what
was used for downloading rustup as part of the build workflow. To
workaround this issue this commit switches to using wget which should do
the certificate checking without any extra arguments across all environments.

At the same time this bumps the cibuildwheel version to the latest across all jobs