### PR TITLE
Add PyDAG methods for ancestors and descendents

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -291,9 +291,37 @@ retworkx API
 .. py:function:: topological_sort(graph):
     Return the topological sort of node indexes from the provided graph
 
-    :param PyDAG first: The DAG to get the topological sort on
+    :param PyDAG graph: The DAG to get the topological sort on
 
     :returns nodes: A list of node indexes topologically sorted.
     :rtype: list
 
     :raises DAGHasCycle: if a cycle is encountered while sorting the graph
+
+.. py:function:: ancestors(graph, node):
+    Return the ancestors of a node in a graph.
+
+    This differs from :py:meth:`PyDAG.predecessors` method  in that
+    predecessors returns only nodes with a direct edge into the provided node.
+    While this function returns all nodes that have a path into the provided
+    node.
+
+    :param PyDAG graph: The DAG to get the descendants from
+    :param int node: The index of the dag to get the ancestors for
+
+    :returns nodes: A list of node indexes of ancestors of provided node.
+    :rtype: list
+
+.. py:function:: descendants(graph, node):
+    Return the descendants of a node in a graph.
+
+    This differs from :py:meth:`PyDAG.successors` method in that
+    predecessors returns only nodes with a direct edge out of the provided node.
+    While this function returns all nodes that have a path from the provided
+    node.
+
+    :param PyDAG graph: The DAG to get the descendants from
+    :param int node: The index of the dag to get the descendants for
+
+    :returns nodes: A list of node indexes of descendants of provided node.
+    :rtype: list

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,7 +600,7 @@ fn dag_longest_path_length(graph: &PyDAG) -> PyResult<usize> {
         }
     };
     let first_v = *first.1;
-    let mut v = first_v.0;
+    let mut v = first_v.1;
     let mut path: Vec<usize> = Vec::new();
     while match u {
         Some(u) => u != v,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,6 +672,32 @@ fn topological_sort(py: Python, graph: &PyDAG) -> PyResult<PyObject> {
     Ok(PyList::new(py, out).into())
 }
 
+#[pyfunction]
+fn ancestors(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
+    let index = NodeIndex::new(node);
+    let mut out_list: Vec<usize> = Vec::new();
+    for n in graph.graph.node_indices() {
+        let n_int = n.index();
+        if n_int != node && algo::has_path_connecting(graph, n, index, None) {
+            out_list.push(n_int);
+        }
+    }
+    Ok(PyList::new(py, out_list).into())
+}
+
+#[pyfunction]
+fn descendants(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
+    let index = NodeIndex::new(node);
+    let mut out_list: Vec<usize> = Vec::new();
+    for n in graph.graph.node_indices() {
+        let n_int = n.index();
+        if n_int != node && algo::has_path_connecting(graph, index, n, None) {
+            out_list.push(n_int);
+        }
+    }
+    Ok(PyList::new(py, out_list).into())
+}
+
 //#[pyfunction]
 //fn lexicographical_topological_sort(graph: PyDAG,
 //                                    key: &PyObject) {
@@ -687,6 +713,8 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(is_isomorphic))?;
     m.add_wrapped(wrap_pyfunction!(is_isomorphic_node_match))?;
     m.add_wrapped(wrap_pyfunction!(topological_sort))?;
+    m.add_wrapped(wrap_pyfunction!(descendants))?;
+    m.add_wrapped(wrap_pyfunction!(ancestors))?;
     //    m.add_wrapped(wrap_pyfunction!(lexicographical_topological_sort))?;
     m.add_class::<PyDAG>()?;
     Ok(())

--- a/tests/test_ancestors_descendants.py
+++ b/tests/test_ancestors_descendants.py
@@ -1,0 +1,63 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestAncestors(unittest.TestCase):
+    def test_ancestors(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {'a': 1})
+        node_c = dag.add_child(node_b, 'c', {'a': 2})
+        res = retworkx.ancestors(dag, node_c)
+        self.assertEqual([node_a, node_b], res)
+
+    def test_no_ancestors(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        dag.add_child(node_a, 'b', {'a': 1})
+        res = retworkx.ancestors(dag, node_a)
+        self.assertEqual([], res)
+
+    def test_ancestors_no_descendants(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {'a': 1})
+        dag.add_child(node_b, 'c', {'b': 1})
+        res = retworkx.ancestors(dag, node_b)
+        self.assertEqual([node_a], res)
+
+class TestDescendants(unittest.TestCase):
+    def test_descendants(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {'a': 1})
+        node_c = dag.add_child(node_b, 'c', {'a': 2})
+        res = retworkx.descendants(dag, node_a)
+        self.assertEqual([node_b, node_c], res)
+
+    def test_no_descendants(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        res = retworkx.descendants(dag, node_a)
+        self.assertEqual([], res)
+
+    def test_descendants_no_ancestors(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {'a': 1})
+        node_c = dag.add_child(node_b, 'c', {'b': 1})
+        res = retworkx.descendants(dag, node_b)
+        self.assertEqual([node_c], res)

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -49,7 +49,7 @@ class TestLongestPath(unittest.TestCase):
         dag.add_edge(node_a, node_c, {})
         dag.add_edge(node_a, node_e, {})
         dag.add_edge(node_c, node_e, {})
-        self.assertEqual(5, retworkx.dag_longest_path_length(dag))
+        self.assertEqual(4, retworkx.dag_longest_path_length(dag))
 
     def test_degenerate_graph(self):
         dag = retworkx.PyDAG()


### PR DESCRIPTION
This commit adds 2 new methods for getting the list of ancestors and
descendants of a node.