### PR TITLE
Add lexicographical topological sort function

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -298,6 +298,21 @@ retworkx API
 
     :raises DAGHasCycle: if a cycle is encountered while sorting the graph
 
+.. py:function:: lexicogrpahical_topological_sort(dag, key):
+    Get the lexicographical topological sorted nodes' data from the provided dag
+
+    This function returns a list of nodes in a graph lexicographically
+    topologically sorted using the provided key function.
+
+    :param PyDAG dag: The DAG to get the topological sorted nodes from
+    :param function key: Takes in a python function or other callable that
+        gets passed a single argument the node data from the graph and is
+        expected to return a string.
+
+    :returns nodes: A list of node's data lexicographically topologically
+        sorted.
+    :rtype: list
+
 .. py:function:: ancestors(graph, node):
     Return the ancestors of a node in a graph.
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -15,7 +15,7 @@ import unittest
 import retworkx
 
 
-class TestEdges(unittest.TestCase):
+class TestNodes(unittest.TestCase):
 
     def test_nodes(self):
         dag = retworkx.PyDAG()
@@ -40,6 +40,17 @@ class TestEdges(unittest.TestCase):
         dag.add_parent(3, 'A parent', None)
         res = retworkx.topological_sort(dag)
         self.assertEqual([6, 0, 5, 4, 3, 2, 1], res)
+
+    def test_lexicographical_topo_sort(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        for i in range(5):
+            dag.add_child(node_a, i, None)
+        dag.add_parent(3, 'A parent', None)
+        res = retworkx.lexicographical_topological_sort(dag, lambda x: str(x))
+        # Node values for nodes [6, 0, 5, 4, 3, 2, 1]
+        expected = ['A parent', 'a', 4, 3, 2, 1, 0]
+        self.assertEqual(expected, res)
 
     def test_get_node_data(self):
         dag = retworkx.PyDAG()


### PR DESCRIPTION
This commit adds a function to retworkx that implements a
lexicographical topological sort for a PyDAG object. It takes in a
mandatory sort function that will take in a node's data and return a
string. This returned string is used as the key for sorting.