### PR TITLE
Fix issues with multigraphs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,20 +466,12 @@ impl PyDAG {
     pub fn in_edges(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Incoming;
-        let neighbors = self.graph.neighbors_directed(index, dir);
         let mut out_list: Vec<PyObject> = Vec::new();
-        for neighbor in neighbors {
-            let edge = match self.graph.find_edge(neighbor, index) {
-                Some(edge) => edge,
-                None => {
-                    return Err(NoEdgeBetweenNodes::py_err(
-                        "No edge found between nodes",
-                    ))
-                }
-            };
-            let edge_w = self.graph.edge_weight(edge);
+        let raw_edges = self.graph.edges_directed(index, dir);
+        for edge in raw_edges {
+            let edge_w = edge.weight();
             let triplet =
-                (neighbor.index(), node, edge_w.unwrap()).to_object(py);
+                (edge.source().index(), node, edge_w).to_object(py);
             out_list.push(triplet)
         }
         Ok(PyList::new(py, out_list).into())
@@ -488,20 +480,12 @@ impl PyDAG {
     pub fn out_edges(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Outgoing;
-        let neighbors = self.graph.neighbors_directed(index, dir);
         let mut out_list: Vec<PyObject> = Vec::new();
-        for neighbor in neighbors {
-            let edge = match self.graph.find_edge(index, neighbor) {
-                Some(edge) => edge,
-                None => {
-                    return Err(NoEdgeBetweenNodes::py_err(
-                        "No edge found between nodes",
-                    ))
-                }
-            };
-            let edge_w = self.graph.edge_weight(edge);
+        let raw_edges = self.graph.edges_directed(index, dir);
+        for edge in raw_edges {
+            let edge_w = edge.weight();
             let triplet =
-                (node, neighbor.index(), edge_w.unwrap()).to_object(py);
+                (node, edge.target().index(), edge_w).to_object(py);
             out_list.push(triplet)
         }
         Ok(PyList::new(py, out_list).into())
@@ -519,14 +503,14 @@ impl PyDAG {
     pub fn in_degree(&self, node: usize) -> usize {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Incoming;
-        let neighbors = self.graph.neighbors_directed(index, dir);
+        let neighbors = self.graph.edges_directed(index, dir);
         neighbors.count()
     }
 
     pub fn out_degree(&self, node: usize) -> usize {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Outgoing;
-        let neighbors = self.graph.neighbors_directed(index, dir);
+        let neighbors = self.graph.edges_directed(index, dir);
         neighbors.count()
     }
 }


### PR DESCRIPTION
A couple of utility functions, mainly *_edges() and *_degree were not
dealing with multigraphs correctly. This is because all these functions
were mistakenly dealing with nodes instead of edges. This would mean
results were missing or were undercounting in the case when there were
multiple edges between 2 nodes. This commit fixes this by switching to
use petgraph's edges_directed() method instead of the
neighbors_directed().