### PR TITLE
Add support for pickling/deepcopy on PyDAG

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,6 +10,10 @@ retworkx API
    the PyDAG class is that an integer node and edge index is used for accessing
    elements on the DAG, not the data/weight of nodes and edges.
 
+     .. note::
+          When using ``copy.deepcopy()`` or pickling node indexes are not
+          guaranteed to be preserved.
+
     .. py:method:: __init__(self):
         Initialize an empty DAG.
 

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -1,0 +1,29 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import copy
+import unittest
+
+import retworkx
+
+
+class TestDeepcopy(unittest.TestCase):
+
+    def test_isomorphic_compare_nodes_identical(self):
+        dag_a = retworkx.PyDAG()
+        node_a = dag_a.add_node('a_1')
+        dag_a.add_child(node_a, 'a_2', 'a_1')
+        dag_a.add_child(node_a, 'a_3', 'a_2')
+        dag_b = copy.deepcopy(dag_a)
+        self.assertTrue(
+            retworkx.is_isomorphic_node_match(
+                dag_a, dag_b, lambda x, y: x == y))


### PR DESCRIPTION
This commit adds support for pickling and running copy.deepcopy() on
PyDAG objects. To do this 3 things are done, first it sets the module
for the class definition to be 'retworkx' instead of the default
builtins. Then it adds a `__getstate__` method to return a dictionary
that can be used reconstruct the contents of the graph and `__setstate__`
which takes in that dictionary and builds a new graph StableDiGraph
object from that. It's worth noting post a deepcopy() the node indices
may not be the same if there were any removals in the original PyDAG
object.