### PR TITLE
Add CI jobs for other architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ jobs:
     - name: Python 3.7 Tests s390x Linux
       python: 3.7
       arch: s390x
+      dist: bionic
       env:
         - RUST_BACKTRACE=full
     - name: Python 3.7 Tests arm64 Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ install:
 script:
     - cd tests && ../test-venv/bin/python -m unittest discover .
 jobs:
+  fast_finish: true
+  allow_failures:
+    - name: Python 3.7 Tests s390x Linux
   include:
     - name: Python 3.5 Tests Linux
       python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,6 @@ script:
     - cd tests && ../test-venv/bin/python -m unittest discover .
 jobs:
   fast_finish: true
-  allow_failures:
-    - name: Python 3.7 Tests s390x Linux
   include:
     - name: Python 3.5 Tests Linux
       python: 3.5
@@ -64,15 +62,15 @@ jobs:
     - name: Python 3.7 Tests ppc64le Linux
       python: 3.7
       arch: ppc64le
+      dist: bionic
     - name: Python 3.7 Tests s390x Linux
       python: 3.7
       arch: s390x
       dist: bionic
-      env:
-        - RUST_BACKTRACE=full
     - name: Python 3.7 Tests arm64 Linux
       python: 3.7
       arch: arm64
+      dist: bionic
     - name: Python 3.5 Tests OSX
       <<: *stage_osx
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 notifications:
     email: false
 
+os: linux
 cache: pip
 
 stage_osx: &stage_osx
@@ -57,7 +58,15 @@ jobs:
     - name: Python 3.8 Tests Linux
       python: 3.8
       dist: bionic
-
+    - name: Python 3.7 Tests ppc64le Linux
+      python: 3.7
+      arch: ppc64le
+    - name: Python 3.7 Tests s390x Linux
+      python: 3.7
+      arch: s390x
+    - name: Python 3.7 Tests arm64 Linux
+      python: 3.7
+      arch: arm64
     - name: Python 3.5 Tests OSX
       <<: *stage_osx
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ jobs:
     - name: Python 3.7 Tests s390x Linux
       python: 3.7
       arch: s390x
+      env:
+        - RUST_BACKTRACE=full
     - name: Python 3.7 Tests arm64 Linux
       python: 3.7
       arch: arm64


### PR DESCRIPTION
This commit adds ci jobs for testing on non-x86 architectures. Non-x86
architectures will only run a single python 3.7 job. Now that the
manylinux2014 spec [1] exists we can start publishing wheels for non-x86
architectures. Adding test jobs is the first step towards that goal.

[1] https://www.python.org/dev/peps/pep-0599/