### PR TITLE
Add bfs_successors function

### DIFF
--- a/tests/test_pred_succ.py
+++ b/tests/test_pred_succ.py
@@ -55,3 +55,52 @@ class TestSuccessors(unittest.TestCase):
                           {'numeral': 6}, {'numeral': 5}, {'numeral': 4},
                           {'numeral': 3}, {'numeral': 2}, {'numeral': 1},
                           {'numeral': 0}], res)
+
+class TestSuccessors(unittest.TestCase):
+    def test_single_successor(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {'a': 1})
+        node_c = dag.add_child(node_b, 'c', {'a': 2})
+        dag.add_child(node_c, 'd', {'a': 1})
+        res = retworkx.bfs_successors(dag, node_b)
+        self.assertEqual([('b', ['c']), ('c', ['d'])], res)
+
+    def test_many_children(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        for i in range(10):
+            dag.add_child(node_a, {'numeral': i}, {'edge': i})
+        res = retworkx.bfs_successors(dag, node_a)
+        self.assertEqual([('a', [{'numeral': 9}, {'numeral': 8}, {'numeral': 7},
+                          {'numeral': 6}, {'numeral': 5}, {'numeral': 4},
+                          {'numeral': 3}, {'numeral': 2}, {'numeral': 1},
+                          {'numeral': 0}])], res)
+
+    def test_bfs_succesors(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node(0)
+        node_b = dag.add_child(node_a, 1, {})
+        node_c = dag.add_child(node_b, 2, {})
+        node_d = dag.add_child(node_c, 3, {})
+        node_e = dag.add_child(node_d, 4, {})
+        node_f = dag.add_child(node_e, 5, {})
+        dag.add_child(node_f, 6, {})
+        node_h = dag.add_child(node_c, 7, {})
+        node_i = dag.add_child(node_h, 8, {})
+        node_j = dag.add_child(node_i, 9, {})
+        dag.add_child(node_j, 10, {})
+        res = {n: sorted(s) for n, s in retworkx.bfs_successors(dag, node_b)}
+        expected = {
+            1: [2],
+            2: [3, 7],
+            3: [4],
+            4: [5],
+            5: [6],
+            7: [8],
+            8: [9],
+            9: [10]
+        }
+        self.assertEqual(expected, res)
+        self.assertEqual([(7, [8]), (8, [9]), (9, [10])],
+                         retworkx.bfs_successors(dag, node_h))


### PR DESCRIPTION
This commit adds a bfs_successors function that mirrors the same
function from networkx. It leverages petgraph's bfs visitor struct which
makes the implementation straightforward. There is an outerloop that
does the graph traversal using the Bfs struct and then an inner loop to
return all the children from that node.