### PR TITLE
Add PyDAG.has_edge() method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,15 @@ impl PyDAG {
         PyList::new(py, out).into()
     }
 
+    pub fn has_edge(&self, node_a: usize, node_b: usize) -> bool {
+        let index_a = NodeIndex::new(node_a);
+        let index_b = NodeIndex::new(node_b);
+        match self.graph.find_edge(index_a, index_b) {
+            Some(_) => true,
+            None => false,
+        }
+    }
+
     pub fn successors(&self, py: Python, node: usize) -> PyResult<PyObject> {
         let index = NodeIndex::new(node);
         let children = self

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -40,6 +40,18 @@ class TestEdges(unittest.TestCase):
         self.assertRaises(Exception, dag.get_edge_data,
                           node_a, node_b)
 
+    def test_has_edge(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {})
+        self.assertTrue(dag.has_edge(node_a, node_b))
+
+    def test_has_edge_no_edge(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_node('b')
+        self.assertFalse(dag.has_edge(node_a, node_b))
+
     def test_edges(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')


### PR DESCRIPTION
This commit adds a new method to the PyDAG class, has_edge(). Like it's
name implies this method returns a boolean value, true if there is an
edge between the nodes specified, and false if there is not.