### PR TITLE
Don't add duplicates to successors or predecessors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,10 +314,7 @@ impl PyDAG {
     pub fn has_edge(&self, node_a: usize, node_b: usize) -> bool {
         let index_a = NodeIndex::new(node_a);
         let index_b = NodeIndex::new(node_b);
-        match self.graph.find_edge(index_a, index_b) {
-            Some(_) => true,
-            None => false,
-        }
+        self.graph.find_edge(index_a, index_b).is_some()
     }
 
     pub fn successors(&self, py: Python, node: usize) -> PyResult<PyObject> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ extern crate pyo3;
 mod dag_isomorphism;
 
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::ops::{Index, IndexMut};
 
 use pyo3::class::PyMappingProtocol;
@@ -326,8 +326,12 @@ impl PyDAG {
             .graph
             .neighbors_directed(index, petgraph::Direction::Outgoing);
         let mut succesors: Vec<&PyObject> = Vec::new();
+        let mut used_indexes: HashSet<NodeIndex> = HashSet::new();
         for succ in children {
-            succesors.push(self.graph.node_weight(succ).unwrap());
+            if !used_indexes.contains(&succ) {
+                succesors.push(self.graph.node_weight(succ).unwrap());
+                used_indexes.insert(succ);
+            }
         }
         Ok(PyList::new(py, succesors).into())
     }
@@ -338,8 +342,12 @@ impl PyDAG {
             .graph
             .neighbors_directed(index, petgraph::Direction::Incoming);
         let mut predec: Vec<&PyObject> = Vec::new();
+        let mut used_indexes: HashSet<NodeIndex> = HashSet::new();
         for pred in parents {
-            predec.push(self.graph.node_weight(pred).unwrap());
+            if !used_indexes.contains(&pred) {
+                predec.push(self.graph.node_weight(pred).unwrap());
+                used_indexes.insert(pred);
+            }
         }
         Ok(PyList::new(py, predec).into())
     }

--- a/tests/test_pred_succ.py
+++ b/tests/test_pred_succ.py
@@ -75,7 +75,7 @@ class TestSuccessors(unittest.TestCase):
                           {'numeral': 3}, {'numeral': 2}, {'numeral': 1},
                           {'numeral': 0}], res)
 
-class TestSuccessors(unittest.TestCase):
+class TestBfsSuccessors(unittest.TestCase):
     def test_single_successor(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')

--- a/tests/test_pred_succ.py
+++ b/tests/test_pred_succ.py
@@ -24,6 +24,15 @@ class TestPredecessors(unittest.TestCase):
         res = dag.predecessors(node_c)
         self.assertEqual(['a'], res)
 
+    def test_single_predecessor_multiple_edges(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {'a': 1})
+        node_c = dag.add_child(node_a, 'c', {'a': 2})
+        dag.add_edge(node_a, node_c, {'a': 3})
+        res = dag.predecessors(node_c)
+        self.assertEqual(['a'], res)
+
     def test_many_parents(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
@@ -42,6 +51,16 @@ class TestSuccessors(unittest.TestCase):
         node_b = dag.add_child(node_a, 'b', {'a': 1})
         node_c = dag.add_child(node_b, 'c', {'a': 2})
         dag.add_child(node_c, 'd', {'a': 1})
+        res = dag.successors(node_b)
+        self.assertEqual(['c'], res)
+
+    def test_single_successor_multiple_edges(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {'a': 1})
+        node_c = dag.add_child(node_b, 'c', {'a': 2})
+        dag.add_child(node_c, 'd', {'a': 1})
+        dag.add_edge(node_b, node_c, {'a': 3})
         res = dag.successors(node_b)
         self.assertEqual(['c'], res)
 


### PR DESCRIPTION
There was a bug in the output from the successors and predecessors
methods for the PyDAG class with multigraphs. If there were multiple
edges to a node the output list would return the same node data twice.
This was unexpected because there is only one successor node not
multiple. To fix this issue this commit only adds a node to the output
of these methods once.