### PR TITLE
Fix incorrect comparison ordering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -804,7 +804,7 @@ fn lexicographical_topological_sort(
             other
                 .key
                 .cmp(&self.key)
-                .then_with(|| self.node.index().cmp(&other.node.index()))
+                .then_with(|| other.node.index().cmp(&self.node.index()))
         }
     }
 


### PR DESCRIPTION
This commit fixes a small oversight in the string comparison function
for the lexicographical topological sort function. In the fallback case
we incorrectly reversing the order of the comparison for the node ids.
This resulted in a reverse sort for keys that were the same.