### PR TITLE
Implement floyd warshall: the shortest paths between every pair of nodes

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -277,7 +277,7 @@ retworkx API
 .. py:function:: is_isomorphic(first, second):
     Determine if 2 DAGS are structurally isomorphic.
 
-    This checks igf 2 graphs are structurally isomorphic (it doesn't match
+    This checks if 2 graphs are structurally isomorphic (it doesn't match
     the contents of the nodes or edges on the dag).
 
     :param PyDAG first: The first DAG to compare
@@ -290,7 +290,7 @@ retworkx API
 .. py:function:: is_isomorphic_node_match(first, second, matcher):
     Determine if 2 DAGS are structurally isomorphic.
 
-    This checks igf 2 graphs are isomorphic both structurally and also comparing
+    This checks if 2 graphs are isomorphic both structurally and also comparing
     the node data using the provided matcher function. The matcher function
     takes in 2 node data objects and will compare them. A simple example that
     checks if they're just equal would be::
@@ -375,3 +375,33 @@ retworkx API
 
     :returns nodes: A list of nodes's data and their children in bfs order
     :rtype: list
+
+.. py:function:: floyd_warshall(graph):
+    Return the shortest path lengths between every pair of nodes that has a
+    path connecting them.
+
+    The runtime is :math:`O(|N|^3 + |E|)` where :math:`|N|` is the number
+    of nodes and :math:`|E|` is the number of edges.
+
+    This is done with the Floyd Warshall algorithm:
+    
+    1. Process all edges by setting the distance from the parent to
+       the child equal to the edge weight.
+    2. Iterate through every pair of nodes (source, target) and an additional
+       itermediary node (w). If the distance from source :math:`\rightarrow` w
+       :math:`\rightarrow` target is less than the distance from source
+       :math:`\rightarrow` target, update the source :math:`\rightarrow` target
+       distance (to pass through w).
+
+    The return format is ``{Source Node: {Target Node: Distance}}``.
+
+    .. note::
+
+        Paths that do not exist are simply not found in the return dictionary,
+        rather than setting the distance to infinity, or -1.
+
+    .. note::
+
+        Edge weights are restricted to 1 in the current implementation.
+
+    :param PyDAG graph: The DAG to get all shortest paths from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ extern crate pyo3;
 
 mod dag_isomorphism;
 
-use std::cmp::Ordering;
 use std::cmp::min;
+use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::ops::{Index, IndexMut};
 
@@ -852,11 +852,7 @@ fn lexicographical_topological_sort(
 // algorithm
 // Note: Edge weights are assumed to be 1
 #[pyfunction]
-fn floyd_warshall(
-    py: Python,
-    dag: &PyDAG,
-) -> PyResult<PyObject> {
-
+fn floyd_warshall(py: Python, dag: &PyDAG) -> PyResult<PyObject> {
     let mut dist: HashMap<(usize, usize), usize> = HashMap::new();
     for node in dag.graph.node_indices() {
         // Distance from a node to itself is zero
@@ -879,15 +875,15 @@ fn floyd_warshall(
             for v in dag.graph.node_indices() {
                 let u_v_dist = match dist.get(&(u.index(), v.index())) {
                     Some(u_v_dist) => *u_v_dist,
-                    None => std::usize::MAX
+                    None => std::usize::MAX,
                 };
                 let u_w_dist = match dist.get(&(u.index(), w.index())) {
                     Some(u_w_dist) => *u_w_dist,
-                    None => std::usize::MAX
+                    None => std::usize::MAX,
                 };
                 let w_v_dist = match dist.get(&(w.index(), v.index())) {
                     Some(w_v_dist) => *w_v_dist,
-                    None => std::usize::MAX
+                    None => std::usize::MAX,
                 };
                 if u_w_dist == std::usize::MAX || w_v_dist == std::usize::MAX {
                     // Avoid overflow!
@@ -907,7 +903,8 @@ fn floyd_warshall(
         let v_index = nodes.1;
         if out_dict.contains(u_index)? {
             let u_dict = out_dict
-                .get_item(u_index).unwrap()
+                .get_item(u_index)
+                .unwrap()
                 .downcast_ref::<PyDict>()?;
             u_dict.set_item(v_index, distance);
             out_dict.set_item(u_index, u_dict)?;

--- a/tests/test_floyd_warshall.py
+++ b/tests/test_floyd_warshall.py
@@ -1,0 +1,73 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestFloydWarshall(unittest.TestCase):
+
+    def test_floyd_warshall(self):
+        """Test the algorithm on a 5q x 4 depth circuit."""
+        dag = retworkx.PyDAG()
+        # inputs
+        qr_0 = dag.add_node('qr[0]')
+        qr_1 = dag.add_node('qr[1]')
+        qr_2 = dag.add_node('qr[2]')
+        cr_0 = dag.add_node('cr[0]')
+        cr_1 = dag.add_node('cr[1]')
+        # wires
+        cx_1 = dag.add_node('cx_1')
+        dag.add_edge(qr_0, cx_1, 'qr[0]')
+        dag.add_edge(qr_1, cx_1, 'qr[1]')
+        h_1 = dag.add_node('h_1')
+        dag.add_edge(cx_1, h_1, 'qr[0]')
+        cx_2 = dag.add_node('cx_2')
+        dag.add_edge(cx_1, cx_2, 'qr[1]')
+        dag.add_edge(qr_2, cx_2, 'qr[2]')
+        cx_3 = dag.add_node('cx_3')
+        dag.add_edge(h_1, cx_3, 'qr[0]')
+        dag.add_edge(cx_2, cx_3, 'qr[2]')
+        h_2 = dag.add_node('h_2')
+        dag.add_edge(cx_3, h_2, 'qr[2]')
+        # # outputs
+        qr_0_out = dag.add_node('qr[0]_out')
+        dag.add_edge(cx_3, qr_0_out, 'qr[0]')
+        qr_1_out = dag.add_node('qr[1]_out')
+        dag.add_edge(cx_2, qr_1_out, 'qr[1]')
+        qr_2_out = dag.add_node('qr[2]_out')
+        dag.add_edge(h_2, qr_2_out, 'qr[2]')
+        cr_0_out = dag.add_node('cr[0]_out')
+        dag.add_edge(cr_0, cr_0_out, 'qr[2]')
+        cr_1_out = dag.add_node('cr[1]_out')
+        dag.add_edge(cr_1, cr_1_out, 'cr[1]')
+        
+        result = retworkx.floyd_warshall(dag)
+        expected = {
+            0: {0: 0, 5: 1, 6: 2, 7: 2, 8: 3, 9: 4, 10: 4, 11: 3, 12: 5},
+            1: {1: 0, 5: 1, 6: 2, 7: 2, 8: 3, 9: 4, 10: 4, 11: 3, 12: 5},
+            2: {2: 0, 7: 1, 8: 2, 9: 3, 10: 3, 11: 2, 12: 4},
+            3: {3: 0, 13: 1},
+            4: {4: 0, 14: 1},
+            5: {5: 0, 6: 1, 7: 1, 8: 2, 9: 3, 10: 3, 11: 2, 12: 4},
+            6: {6: 0, 8: 1, 9: 2, 10: 2, 12: 3},
+            7: {7: 0, 8: 1, 9: 2, 10: 2, 11: 1, 12: 3},
+            8: {8: 0, 9: 1, 10: 1, 12: 2},
+            9: {9: 0, 12: 1},
+            10: {10: 0},
+            11: {11: 0},
+            12: {12: 0},
+            13: {13: 0},
+            14: {14: 0},
+        }
+        self.assertDictEqual(result, expected)


### PR DESCRIPTION
Returns `Dict[int, Dict[int, int]]` where keys are node *indices* and final value is distance. If a path does not exist, there is no entry in the returned dictionary. This is different from networkx, where `inf` fills the place of paths that don't exist.

I couldn't find a way to get `inf` returned :(