### PR TITLE
Make cycle checking opt-in

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,7 +8,18 @@ retworkx API
    the ``StableGraph`` type. The limitations and quirks with this library and
    type dictate how this operates. The biggest thing to be aware of when using
    the PyDAG class is that an integer node and edge index is used for accessing
-   elements on the DAG, not the data/weight of nodes and edges.
+   elements on the DAG, not the data/weight of nodes and edges. By default the
+   PyDAG realtime cycle checking is disabled for performance, however you can
+   opt-in to having the PyDAG class ensure that no cycles are added by setting
+   the ``check_cycle`` attribute to True. For example::
+
+       import retworkx
+       dag = retworkx.PyDAG()
+       dag.check_cycle = True
+
+   With check_cycle set to true any calls to :method:`PyDAG.add_edge` will
+   ensure that no cycles are added, ensuring that the PyDAG class truly
+   represents a directed acyclic graph.
 
      .. note::
           When using ``copy.deepcopy()`` or pickling node indexes are not

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,11 @@ impl PyDAG {
 
     #[setter]
     fn set_check_cycle(&mut self, value: bool) -> PyResult<()> {
+        if !self.check_cycle && value {
+            if !is_directed_acyclic_graph(self) {
+                return Err(DAGHasCycle::py_err("PyDAG object has a cycle"));
+            }
+        }
         self.check_cycle = value;
         Ok(())
     }

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -108,6 +108,7 @@ class TestEdges(unittest.TestCase):
 
     def test_add_cycle(self):
         dag = retworkx.PyDAG()
+        dag.check_cycle = True
         node_a = dag.add_node('a')
         node_b = dag.add_child(node_a, 'b', {})
         self.assertRaises(Exception, dag.add_edge, node_b,

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -113,3 +113,11 @@ class TestEdges(unittest.TestCase):
         node_b = dag.add_child(node_a, 'b', {})
         self.assertRaises(Exception, dag.add_edge, node_b,
                           node_a, {})
+
+    def test_enable_cycle_checking_after_edge(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {})
+        dag.add_edge(node_b, node_a, {})
+        with self.assertRaises(Exception):
+            dag.check_cycle = True


### PR DESCRIPTION
Currently the PyDAG class always checks on add_edge() calls that the new
edge would not create a cycle in the dag. However, this comes at a
performance cost, and sometimes depending on the size and complexity of
the dag this can be large. To avoid this performance penalty by default
this commit changes the PyDAG class to not do this checking by default.
It adds a new attribute check_cycle to the class, if this is set to True
then cycle checking is enabled on subsequent calls to add_edge().