### PR TITLE
Add layers function

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -405,3 +405,16 @@ retworkx API
         Edge weights are restricted to 1 in the current implementation.
 
     :param PyDAG graph: The DAG to get all shortest paths from
+
+.. py:function:: layers(graph, first_layer):
+    Return a list of layers
+
+    A layer is a subgraph whose nodes are disjoint, i.e.,
+    a layer has depth 1. The layers are constructed using a greedy algorithm.
+
+    :param PyDAG graph: The DAG to get the layers from
+    :param list first_layer: A list of node ids for the first layer. This
+        will be the first layer in the output
+
+    :returns layers: A list of layers, each layer is a list of node data
+    :rtype: list

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -917,6 +917,78 @@ fn floyd_warshall(py: Python, dag: &PyDAG) -> PyResult<PyObject> {
     Ok(out_dict.into())
 }
 
+#[pyfunction]
+fn layers(
+    py: Python,
+    dag: &PyDAG,
+    first_layer: Vec<usize>,
+) -> PyResult<PyObject> {
+    let mut output: Vec<Vec<&PyObject>> = Vec::new();
+    // Convert usize to NodeIndex
+    let mut first_layer_index: Vec<NodeIndex> = Vec::new();
+    for index in first_layer {
+        first_layer_index.push(NodeIndex::new(index));
+    }
+
+    let mut cur_layer = first_layer_index;
+    let mut next_layer: Vec<NodeIndex> = Vec::new();
+    let mut predecessor_count: HashMap<NodeIndex, usize> = HashMap::new();
+
+    let mut layer_node_data: Vec<&PyObject> = Vec::new();
+    for layer_node in &cur_layer {
+        layer_node_data.push(&dag[*layer_node]);
+    }
+    output.push(layer_node_data);
+
+    // Iterate until there are no more
+    while !cur_layer.is_empty() {
+        for node in &cur_layer {
+            let children = dag
+                .graph
+                .neighbors_directed(*node, petgraph::Direction::Outgoing);
+            let mut used_indexes: HashSet<NodeIndex> = HashSet::new();
+            for succ in children {
+                // Skip duplicate successors
+                if used_indexes.contains(&succ) {
+                    continue;
+                }
+                used_indexes.insert(succ);
+                let mut multiplicity: usize = 0;
+                let raw_edges = dag
+                    .graph
+                    .edges_directed(*node, petgraph::Direction::Outgoing);
+                for edge in raw_edges {
+                    if edge.target() == succ {
+                        multiplicity += 1;
+                    }
+                }
+                if predecessor_count.contains_key(&succ) {
+                    let count = predecessor_count.get_mut(&succ).unwrap();
+                    *count -= multiplicity;
+                } else {
+                    let count: usize =
+                        dag.in_degree(succ.index()) - multiplicity;
+                    predecessor_count.insert(succ, count);
+                }
+                if *predecessor_count.get(&succ).unwrap() == 0 {
+                    next_layer.push(succ);
+                    predecessor_count.remove(&succ);
+                }
+            }
+        }
+        let mut layer_node_data: Vec<&PyObject> = Vec::new();
+        for layer_node in &next_layer {
+            layer_node_data.push(&dag[*layer_node]);
+        }
+        if !layer_node_data.is_empty() {
+            output.push(layer_node_data);
+        }
+        cur_layer = next_layer;
+        next_layer = Vec::new();
+    }
+    Ok(PyList::new(py, output).into())
+}
+
 #[pymodule]
 fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
@@ -932,6 +1004,7 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(ancestors))?;
     m.add_wrapped(wrap_pyfunction!(lexicographical_topological_sort))?;
     m.add_wrapped(wrap_pyfunction!(floyd_warshall))?;
+    m.add_wrapped(wrap_pyfunction!(layers))?;
     m.add_class::<PyDAG>()?;
     Ok(())
 }

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,0 +1,59 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+class TestLayers(unittest.TestCase):
+    def test_dagcircuit_basic(self):
+        dag = retworkx.PyDAG()
+        qr_0_in = dag.add_node("qr[0]")
+        qr_0_out = dag.add_node("qr[0]")
+        qr_1_in = dag.add_node("qr[1]")
+        qr_1_out = dag.add_node("qr[1]")
+        cr_0_in = dag.add_node("cr[0]")
+        cr_0_out = dag.add_node("cr[0]")
+        cr_1_in = dag.add_node("cr[1]")
+        cr_1_out = dag.add_node("cr[1]")
+        input_nodes = [qr_0_in, qr_1_in, cr_0_in, cr_1_in]
+
+        h_gate = dag.add_child(qr_0_in, "h", "qr[0]")
+        cx_gate = dag.add_child(h_gate, "cx", "qr[0]")
+        dag.add_edge(qr_1_in, cx_gate, "qr[1]")
+        measure_qr_1 = dag.add_child(cx_gate, "measure", "qr[1]")
+        dag.add_edge(cr_1_in, measure_qr_1, "cr[1]")
+        x_gate = dag.add_child(measure_qr_1, "x", "qr[1]")
+        dag.add_edge(measure_qr_1, x_gate, "cr[1]")
+        dag.add_edge(cr_0_in, x_gate, "cr[0]")
+
+
+        measure_qr_0 = dag.add_child(cx_gate, "measure", "qr[0]")
+        dag.add_edge(measure_qr_0, qr_0_out, "qr[0]")
+        dag.add_edge(measure_qr_0, cr_0_out, "cr[0]")
+        dag.add_edge(x_gate, measure_qr_0, "cr[0]")
+
+        measure_qr_1_out = dag.add_child(x_gate, "measure", "cr[1]")
+        dag.add_edge(x_gate, measure_qr_1_out, "qr[1]")
+        dag.add_edge(measure_qr_1_out, qr_1_out, "qr[1]")
+        dag.add_edge(measure_qr_1_out, cr_1_out, "cr[1]")
+
+        res = retworkx.layers(dag, input_nodes)
+        expected = [
+            ['qr[0]', 'qr[1]', 'cr[0]', 'cr[1]'],
+            ['h'],
+            ['cx'],
+            ['measure'],
+            ['x'],
+            ['measure', 'measure'],
+            ['cr[1]', 'qr[1]', 'cr[0]', 'qr[0]']]
+        self.assertEqual(expected, res)


### PR DESCRIPTION
This commit adds a function to get layers from a PyDAG object. You
provide it with an inital set of indexes for the first layer and it will
return a list of lists with the node data, where each inner list
represents a layer.