### PR TITLE
Add PyDAG method to get node indexes

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -52,6 +52,12 @@ retworkx API
         :returns: A list of all the node data objects in the DAG
         :rtype: list
 
+    .. py:method:: node_indexes(self):
+        Return a list of all node indexes.
+
+        :returns: A list of all the node indexes in the DAG
+        :rtype: list
+
     .. py:method:: successors(self, node):
         Return a list of all the node successor data.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,14 @@ impl PyDAG {
         PyList::new(py, out).into()
     }
 
+    pub fn node_indexes(&self, py: Python) -> PyObject {
+        let mut out_list: Vec<usize> = Vec::new();
+        for node_index in self.graph.node_indices() {
+            out_list.push(node_index.index());
+        }
+        PyList::new(py, out_list).into()
+    }
+
     pub fn has_edge(&self, node_a: usize, node_b: usize) -> bool {
         let index_a = NodeIndex::new(node_a);
         let index_b = NodeIndex::new(node_b);

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -22,10 +22,12 @@ class TestNodes(unittest.TestCase):
         node_b = dag.add_child(node_a, 'b', "Edgy")
         res = dag.nodes()
         self.assertEqual(['a', 'b'], res)
+        self.assertEqual([0, 1], dag.node_indexes())
 
     def test_no_nodes(self):
         dag = retworkx.PyDAG()
         self.assertEqual([], dag.nodes())
+        self.assertEquals([], dag.node_indexes())
 
     def test_topo_sort_empty(self):
         dag = retworkx.PyDAG()


### PR DESCRIPTION
Currently the nodes() method returns a list of node data, but if for any
reason there is a need to get a list of all the indexes in use by the
PyDAG object the only option right now is to use a function like
topological sort which will return the sorted indexes. However, if
sorting isn't a requirement this is slower than needed. This commit adds
a method node_indexes() which will return a list of all node indexes.