### PR TITLE
Add non-x86 manylinux wheel builds to deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,6 +136,48 @@ jobs:
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
+      arch: arm64
+      services:
+        - docker
+      before_install:
+        - echo ""
+      install:
+        - echo ""
+      env:
+        - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && yum install -y wget && tools/install_rust.sh"
+        - CIBW_SKIP="cp27-* cp34-*"
+        - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
+        - TWINE_USERNAME=retworkx-ci
+        - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
+      if: tag IS present
+      script:
+        - sudo pip install -U twine
+        - git clone https://github.com/joerick/cibuildwheel.git
+        - sudo pip install ./cibuildwheel
+        - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*
+    - stage: deploy
+      arch: ppc64le
+      services:
+        - docker
+      before_install:
+        - echo ""
+      install:
+        - echo ""
+      env:
+        - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && yum install -y wget && tools/install_rust.sh"
+        - CIBW_SKIP="cp27-* cp34-*"
+        - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
+        - TWINE_USERNAME=retworkx-ci
+        - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
+      if: tag IS present
+      script:
+        - sudo pip install -U twine
+        - git clone https://github.com/joerick/cibuildwheel.git
+        - sudo pip install ./cibuildwheel
+        - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*
+    - stage: deploy
       os: osx
       language: generic
       if: tag IS present


### PR DESCRIPTION
This commit adds non-x86 wheel builds to the deploy stage right now it's
built using master of cibuildwheel because support for non-x86 hasn't
been released yet (but the dev version was used to build the currently
hosted non-x86 artifacts on pypi). When a release is available with the
missing support this will be updated in a follow up commit.

Additionally, the s390x support is left out because of an issue
installing rustup in clefos 7 (which is required per the manylinux
2014 spec). Once https://github.com/rust-lang/rustup/issues/2225 is
fixed or worked around this can be added.