### PR TITLE
Add sdist job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,6 +136,20 @@ jobs:
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
+      python: 3.7
+      before_install:
+        - echo ""
+      install:
+        - echo ""
+      env:
+        - TWINE_USERNAME=retworkx-ci
+      before_script:
+        - pip install -U twine
+      if: tag IS present
+      script:
+        - python setup.py sdist
+        - twine upload dist/*
+    - stage: deploy
       arch: arm64
       services:
         - docker


### PR DESCRIPTION
Currently we were not building an sdist at release time and to enable
source installs from pypi we'd have to manually build and upload an
sdist. This commit corrects this by adding a CI job to the deploy stage
which will create an sdist and upload it to pypi.