### PR TITLE
Use Dijkstra's algorithm for ancestors/descendants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ use petgraph::visit::{
     Bfs, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences,
     IntoEdges, IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected,
     IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable, NodeCount,
-    NodeIndexable, Visitable,
+    NodeIndexable, Reversed, Visitable,
 };
 
 #[pyclass(module = "retworkx")]
@@ -786,9 +786,11 @@ fn bfs_successors(
 fn ancestors(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
     let index = NodeIndex::new(node);
     let mut out_list: Vec<usize> = Vec::new();
-    for n in graph.graph.node_indices() {
+    let reverse_graph = Reversed(graph);
+    let res = algo::dijkstra(reverse_graph, index, None, |_| 1);
+    for n in res.keys() {
         let n_int = n.index();
-        if n_int != node && algo::has_path_connecting(graph, n, index, None) {
+        if n_int != node {
             out_list.push(n_int);
         }
     }
@@ -799,9 +801,10 @@ fn ancestors(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
 fn descendants(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
     let index = NodeIndex::new(node);
     let mut out_list: Vec<usize> = Vec::new();
-    for n in graph.graph.node_indices() {
+    let res = algo::dijkstra(graph, index, None, |_| 1);
+    for n in res.keys() {
         let n_int = n.index();
-        if n_int != node && algo::has_path_connecting(graph, index, n, None) {
+        if n_int != node {
             out_list.push(n_int);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -790,10 +790,9 @@ fn ancestors(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
     let res = algo::dijkstra(reverse_graph, index, None, |_| 1);
     for n in res.keys() {
         let n_int = n.index();
-        if n_int != node {
-            out_set.insert(n_int);
-        }
+        out_set.insert(n_int);
     }
+    out_set.remove(&node);
     Ok(out_set.to_object(py))
 }
 
@@ -804,10 +803,9 @@ fn descendants(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
     let res = algo::dijkstra(graph, index, None, |_| 1);
     for n in res.keys() {
         let n_int = n.index();
-        if n_int != node {
-            out_set.insert(n_int);
-        }
+        out_set.insert(n_int);
     }
+    out_set.remove(&node);
     Ok(out_set.to_object(py))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,30 +785,30 @@ fn bfs_successors(
 #[pyfunction]
 fn ancestors(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
     let index = NodeIndex::new(node);
-    let mut out_list: Vec<usize> = Vec::new();
+    let mut out_set: HashSet<usize> = HashSet::new();
     let reverse_graph = Reversed(graph);
     let res = algo::dijkstra(reverse_graph, index, None, |_| 1);
     for n in res.keys() {
         let n_int = n.index();
         if n_int != node {
-            out_list.push(n_int);
+            out_set.insert(n_int);
         }
     }
-    Ok(PyList::new(py, out_list).into())
+    Ok(out_set.to_object(py))
 }
 
 #[pyfunction]
 fn descendants(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
     let index = NodeIndex::new(node);
-    let mut out_list: Vec<usize> = Vec::new();
+    let mut out_set: HashSet<usize> = HashSet::new();
     let res = algo::dijkstra(graph, index, None, |_| 1);
     for n in res.keys() {
         let n_int = n.index();
         if n_int != node {
-            out_list.push(n_int);
+            out_set.insert(n_int);
         }
     }
-    Ok(PyList::new(py, out_list).into())
+    Ok(out_set.to_object(py))
 }
 
 #[pyfunction]

--- a/tests/test_ancestors_descendants.py
+++ b/tests/test_ancestors_descendants.py
@@ -22,7 +22,7 @@ class TestAncestors(unittest.TestCase):
         node_b = dag.add_child(node_a, 'b', {'a': 1})
         node_c = dag.add_child(node_b, 'c', {'a': 2})
         res = retworkx.ancestors(dag, node_c)
-        self.assertEqual([node_a, node_b], res)
+        self.assertEqual([node_a, node_b], sorted(res))
 
     def test_no_ancestors(self):
         dag = retworkx.PyDAG()
@@ -46,7 +46,7 @@ class TestDescendants(unittest.TestCase):
         node_b = dag.add_child(node_a, 'b', {'a': 1})
         node_c = dag.add_child(node_b, 'c', {'a': 2})
         res = retworkx.descendants(dag, node_a)
-        self.assertEqual([node_b, node_c], res)
+        self.assertEqual([node_b, node_c], sorted(res))
 
     def test_no_descendants(self):
         dag = retworkx.PyDAG()

--- a/tests/test_ancestors_descendants.py
+++ b/tests/test_ancestors_descendants.py
@@ -22,14 +22,14 @@ class TestAncestors(unittest.TestCase):
         node_b = dag.add_child(node_a, 'b', {'a': 1})
         node_c = dag.add_child(node_b, 'c', {'a': 2})
         res = retworkx.ancestors(dag, node_c)
-        self.assertEqual([node_a, node_b], sorted(res))
+        self.assertEqual({node_a, node_b}, res)
 
     def test_no_ancestors(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
         dag.add_child(node_a, 'b', {'a': 1})
         res = retworkx.ancestors(dag, node_a)
-        self.assertEqual([], res)
+        self.assertEqual(set(), res)
 
     def test_ancestors_no_descendants(self):
         dag = retworkx.PyDAG()
@@ -37,7 +37,7 @@ class TestAncestors(unittest.TestCase):
         node_b = dag.add_child(node_a, 'b', {'a': 1})
         dag.add_child(node_b, 'c', {'b': 1})
         res = retworkx.ancestors(dag, node_b)
-        self.assertEqual([node_a], res)
+        self.assertEqual({node_a}, res)
 
 class TestDescendants(unittest.TestCase):
     def test_descendants(self):
@@ -46,13 +46,13 @@ class TestDescendants(unittest.TestCase):
         node_b = dag.add_child(node_a, 'b', {'a': 1})
         node_c = dag.add_child(node_b, 'c', {'a': 2})
         res = retworkx.descendants(dag, node_a)
-        self.assertEqual([node_b, node_c], sorted(res))
+        self.assertEqual({node_b, node_c}, res)
 
     def test_no_descendants(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
         res = retworkx.descendants(dag, node_a)
-        self.assertEqual([], res)
+        self.assertEqual(set(), res)
 
     def test_descendants_no_ancestors(self):
         dag = retworkx.PyDAG()
@@ -60,4 +60,4 @@ class TestDescendants(unittest.TestCase):
         node_b = dag.add_child(node_a, 'b', {'a': 1})
         node_c = dag.add_child(node_b, 'c', {'b': 1})
         res = retworkx.descendants(dag, node_b)
-        self.assertEqual([node_c], res)
+        self.assertEqual({node_c}, res)


### PR DESCRIPTION
The previous implementation of the ancestors and descendants functions
were exceedingly inefficient. They iterated over each node in the graph
and then did a connectivity check between that node and the source or
target. For large graphs this could result in major bottleneck because
this is needlessly traversing the graph multiple times. This commit
reworks the internals of these functions to use Dijkstra's algorithm to
find paths from or to the specified node. This actually matches how
networkx implements these functions and should significantly improve
the runtime performance of the functions. 

The only tradeoff with this is that results come back unordered now
instead of node creation ordered as with the prior implementation.